### PR TITLE
Fix documentation link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,4 +26,4 @@ which runs on the same Python kernel as the UI.
 For further information, see the full documentation_.
 
 .. _HyperSpy: http://hyperspy.org
-.. _documentation: http://hyperspy.github.io/hyperspyUI/
+.. _documentation: http://hyperspy.org/hyperspyUI/

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ While the UI tries to create a simple and intuitive interface to HyperSpy, it
 still retains the raw power of HyperSpy via the UI’s built in IPython console,
 which runs on the same Python kernel as the UI.
 
-For further information, see the documentation at
-http://vidartf.github.io/hyperspyUI/.
+For further information, see the full documentation_.
 
 .. _HyperSpy: http://hyperspy.org
+.. _documentation: http://hyperspy.github.io/hyperspyUI/


### PR DESCRIPTION
While browsing the new repo, I found a small error in the readme. Documentation link 404'd because of the change in repo ownership.