### PR TITLE
Ensure null `cur_dir` does not prevent save/load

### DIFF
--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -305,7 +305,7 @@ class MainWindowUtils(MainWindowBase):
                      title=None, def_filter=None):
         if title is None:
             title = tr('Load file') if exists else tr('Save file')
-        path = path or self.cur_dir
+        path = path or self.cur_dir or ''
         if def_filter is None and extension_filter:
             def_filter = extension_filter.split(';;', maxsplit=1)[0]
 


### PR DESCRIPTION
Fixes #82. Fixes #76.

Should fix errors where `cur_dir` not being set to a valid value caused file prompt dialogs failing.