### PR TITLE
Mac Icon, Help menu and bring app to front on launch

### DIFF
--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -27,6 +27,7 @@ import argparse
 import os
 import sys
 import json
+import webbrowser
 
 import numpy as np
 
@@ -186,6 +187,11 @@ class MainWindow(MainWindowHyperspy):
         self.add_action('edit_settings', "Edit settings", self.edit_settings,
                         tip="Edit the application and plugins settings")
 
+        # Help:
+        self.add_action('documentation', "Documentation",
+                        self.open_documentation,
+                        tip="Open the HyperSpyUI documentation in a browser.")
+
         # --- Add signal type selection actions ---
         signal_type_ag = QActionGroup(self)
         signal_type_ag.setExclusive(True)
@@ -279,6 +285,7 @@ class MainWindow(MainWindowHyperspy):
 
         # Create Help menu, so it is searchable on Mac
         self.menus['Help'] = mb.addMenu(tr("&Help"))
+        self.add_menuitem('Help', self.actions['documentation'])
 
     def create_tools(self):
         super(MainWindow, self).create_tools()
@@ -450,3 +457,6 @@ class MainWindow(MainWindowHyperspy):
         if data_type.__module__ == 'numpy':
             dts = 'np.' + dts
         self.record_code("signal.change_dtype(%s)" % dts)
+
+    def open_documentation(self):
+        webbrowser.open('http://hyperspy.org/hyperspyUI/')

--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -102,6 +102,10 @@ class MainWindow(MainWindowHyperspy):
             self._old_stdout = self._old_stderr = None
         logger.info("Main window loaded!")
 
+        # Set the UI in front of other applications
+        self.show()
+        self.raise_()
+
     def handleSecondInstance(self, argv):
         """
         A second instance was launched and suppressed. Process the arguments

--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -273,6 +273,9 @@ class MainWindow(MainWindowHyperspy):
         self.add_menuitem('Settings', self.actions['hspy_settings'])
         self.add_menuitem('Settings', self.actions['edit_settings'])
 
+        # Create Help menu, so it is searchable on Mac
+        self.menus['Help'] = mb.addMenu(tr("&Help"))
+
     def create_tools(self):
         super(MainWindow, self).create_tools()
         for tool_type in hyperspyui.tools.default_tools:

--- a/hyperspyui/singleapplication.py
+++ b/hyperspyui/singleapplication.py
@@ -25,7 +25,10 @@ Created on Thu Nov 27 03:01:19 2014
 import sys
 import json
 import os
+import logging
 from python_qt_binding import QtGui, QtCore, QtNetwork, QT_BINDING
+
+_logger = logging.getLogger(__name__)
 
 
 class SingleApplication(QtGui.QApplication):
@@ -97,10 +100,14 @@ def get_app(key):
             if app.isRunning():
                 msg = json.dumps(sys.argv[1:])
                 app.sendMessage(msg)
+                _logger.debug('An existing instance of HyperSpyUI is running, '
+                              'sending arguments to it.')
                 sys.exit(1)     # An instance is already running
         else:
             app = SingleApplicationWithMessaging(sys.argv, key)
             if app.isRunning():
+                _logger.debug('An existing instance of HyperSpyUI is running, '
+                              'bringing it to the front.')
                 sys.exit(1)     # An instance is already running
     elif QT_BINDING == 'pyside':
         from siding.singleinstance import QSingleApplication

--- a/hyperspyui/singleapplication.py
+++ b/hyperspyui/singleapplication.py
@@ -24,6 +24,7 @@ Created on Thu Nov 27 03:01:19 2014
 
 import sys
 import json
+import os
 from python_qt_binding import QtGui, QtCore, QtNetwork, QT_BINDING
 
 
@@ -40,6 +41,11 @@ class SingleApplication(QtGui.QApplication):
             self._running = False
             if not self._memory.create(1):
                 raise RuntimeError(self._memory.errorString())
+
+        # Set correct logo
+        base_path = os.path.abspath(os.path.dirname(__file__))
+        icon_path = os.path.join(base_path, 'images', 'hyperspy.svg')
+        QtGui.QApplication.setWindowIcon(QtGui.QIcon(icon_path))
 
     def isRunning(self):
         return self._running


### PR DESCRIPTION
I've added support for the hyperspy icon on Mac, so it's no longer the bland icon. This may probably have impacted other OS as well (not sure how it was). I'm not sure if it's in the best place in the code, but it works fine, and I thought it would fit there.

 I've also added a Help menu item which allows Mac users to search amongst all the other options. It's a real jewel if you can't remember where, say, "Rotate" is.

Finally, and this is just my preference, but I've made it so that the UI opens in front of other applications. It's "at the back" of applications in priority on Mac at least.

I don't think any tests are needed.