### PR TITLE
Removed vestigal scripts list from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,6 @@ setup(
             'hyperspyui = hyperspyui.__main__:main',
          ]
     },
-    scripts=[
-        'bin/hyperspyui_install.py',
-        # 'bin/hyperspyui_reg_linux_extensions.sh',
-    ],
     keywords=[
     ],
     classifiers=[


### PR DESCRIPTION
The `scripts` variable causes an error when installing (on windows, at least). Removing it allows for error free install using `pip install -e ./`, and doesn't seem to cause any additional issues.