### PR TITLE
Port to qtpy to support qt5  

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,8 @@ install:
   - "%CMD_IN_ENV% pip install https://github.com/enthought/pyface/archive/master.zip"
   - "%CMD_IN_ENV% pip install https://github.com/enthought/traitsui/archive/master.zip"
 
-  - '%CMD_IN_ENV% pip install pypiwin32'
+  # Try to run twice as workaround for permission error...
+  - '%CMD_IN_ENV% pip install pypiwin32 || pip install pypiwin32'
   - '%CMD_IN_ENV% pip install -e ".[test]"'
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,12 @@ environment:
       PYTHON_MAJOR: 3
       PYTHON_ARCH: "64"
       CONDA_PY: "35"
-      CONDA_NPY: "19"
+
+    - PYTHON: "C:\\Miniconda36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_MAJOR: 3
+      PYTHON_ARCH: "64"
+      CONDA_PY: "36"
 
 cache:
   - '%PYTHON%\pkgs'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - 'SET "PATH=%PYTHON%\\Scripts;%PATH%"'
   # Install most deps by conda
   - '%CMD_IN_ENV% conda config --add channels conda-forge'
+  - '%CMD_IN_ENV% conda update -y conda'
   - '%CMD_IN_ENV% conda install -q -y hyperspy'
   # Install our package:
   - '%CMD_IN_ENV% python -m pip install --upgrade pip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,10 @@ install:
   - '%CMD_IN_ENV% conda install -q -y hyperspy'
   # Install our package:
   - '%CMD_IN_ENV% python -m pip install --upgrade pip'
+  # Remove when pyface 6.0.0 and traitsui 5.2.0 are released
+  - "%CMD_IN_ENV% pip install https://github.com/enthought/pyface/archive/master.zip"
+  - "%CMD_IN_ENV% pip install https://github.com/enthought/traitsui/archive/master.zip"
+
   - '%CMD_IN_ENV% pip install pypiwin32'
   - '%CMD_IN_ENV% pip install -e ".[test]"'
 

--- a/doc/sphinxext/ipython_console_highlighting.py
+++ b/doc/sphinxext/ipython_console_highlighting.py
@@ -54,10 +54,10 @@ class IPythonConsoleLexer(Lexer):
     name = 'IPython console session'
     aliases = ['ipython']
     mimetypes = ['text/x-ipython-console']
-    input_prompt = re.compile("(In \[[0-9]+\]: )|(   \.\.\.+:)")
-    output_prompt = re.compile("(Out\[[0-9]+\]: )|(   \.\.\.+:)")
-    continue_prompt = re.compile("   \.\.\.+:")
-    tb_start = re.compile("\-+")
+    input_prompt = re.compile(r"(In \[[0-9]+\]: )|(   \.\.\.+:)")
+    output_prompt = re.compile(r"(Out\[[0-9]+\]: )|(   \.\.\.+:)")
+    continue_prompt = re.compile(r"   \.\.\.+:")
+    tb_start = re.compile(r"\-+")
 
     def get_tokens_unprocessed(self, text):
         pylexer = PythonLexer(**self.options)

--- a/hyperspyui/__main__.py
+++ b/hyperspyui/__main__.py
@@ -106,7 +106,7 @@ def main():
         splash_pix = QtGui.QPixmap(
             os.path.dirname(__file__) + './images/splash.png')
         splash = QtWidgets.QSplashScreen(splash_pix,
-                                     QtCore.Qt.WindowStaysOnTopHint)
+                                         QtCore.Qt.WindowStaysOnTopHint)
         splash.setMask(splash_pix.mask())
         splash.show()
         app.processEvents()

--- a/hyperspyui/__main__.py
+++ b/hyperspyui/__main__.py
@@ -71,7 +71,7 @@ def _get_logfile():
 
 
 def main():
-    from python_qt_binding import QtGui, QtCore, QT_BINDING
+    from qtpy import QtGui, QtCore, API, QtWidgets
     import hyperspyui.info
     from hyperspyui.singleapplication import get_app
     from hyperspyui.settings import Settings
@@ -90,7 +90,7 @@ def main():
     settings.set_default('allow_multiple_instances', False)
     if settings['allow_multiple_instances', bool]:
         # Using multiple instances, get a new application
-        app = QtGui.QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
     else:
         # Make sure we only have a single instance
         app = get_app('hyperspyui')
@@ -105,7 +105,7 @@ def main():
         # Create and display the splash screen
         splash_pix = QtGui.QPixmap(
             os.path.dirname(__file__) + './images/splash.png')
-        splash = QtGui.QSplashScreen(splash_pix,
+        splash = QtWidgets.QSplashScreen(splash_pix,
                                      QtCore.Qt.WindowStaysOnTopHint)
         splash.setMask(splash_pix.mask())
         splash.show()
@@ -117,9 +117,9 @@ def main():
 
         form = MainWindow()
         if not settings['allow_multiple_instances', bool]:
-            if QT_BINDING == 'pyqt':
+            if "pyqt" in API:
                 app.messageAvailable.connect(form.handleSecondInstance)
-            elif QT_BINDING == 'pyside':
+            elif API == 'pyside':
                 app.messageReceived.connect(form.handleSecondInstance)
         form.showMaximized()
 

--- a/hyperspyui/__main__.py
+++ b/hyperspyui/__main__.py
@@ -73,9 +73,10 @@ def _get_logfile():
 
 
 def main():
-    from qtpy.QtCore import QCoreApplication
+    from qtpy.QtCore import QCoreApplication, Qt
     from qtpy.QtWidgets import QApplication
     from qtpy import API
+
     import hyperspyui.info
     from hyperspyui.settings import Settings
 
@@ -98,6 +99,20 @@ def main():
         from hyperspyui.singleapplication import get_app
         app = get_app('hyperspyui')
 
+    def get_splash():
+        from qtpy.QtWidgets import QApplication, QSplashScreen
+        from qtpy.QtGui import QColor, QPixmap
+        splash_pix = QPixmap(os.path.join(
+            os.path.dirname(__file__), 'images', 'splash.png'))
+        splash = QSplashScreen(splash_pix, Qt.WindowStaysOnTopHint)
+        splash.show()
+        splash.showMessage("Initializing...", Qt.AlignBottom | Qt.AlignCenter |
+                           Qt.AlignAbsolute, QColor(Qt.white))
+        QApplication.processEvents()
+        return splash
+
+    splash = get_splash()
+
     log_file = _get_logfile()
     if log_file:
         sys.stdout = sys.stderr = log_file
@@ -111,7 +126,7 @@ def main():
         # Need to have import here, since QApplication needs to be called first
         from hyperspyui.mainwindow import MainWindow
 
-        form = MainWindow()
+        form = MainWindow(splash=splash)
         if not settings['allow_multiple_instances', bool]:
             if "pyqt" in API:
                 app.messageAvailable.connect(form.handleSecondInstance)
@@ -126,6 +141,7 @@ def main():
         hs.set_log_level(LOGLEVEL)
 
         app.exec_()
+
 
 if __name__ == "__main__":
     locale.setlocale(locale.LC_ALL, '')

--- a/hyperspyui/__main__.py
+++ b/hyperspyui/__main__.py
@@ -24,6 +24,8 @@ Created on Tue Nov 25 02:10:29 2014
 import os
 import sys
 import locale
+from contextlib import contextmanager
+
 
 # TODO: Make sure tools are disconnected when closing signal!
 
@@ -100,7 +102,9 @@ def main():
     if log_file:
         sys.stdout = sys.stderr = log_file
     else:
-        from hyperspyui.util import dummy_context_manager
+        @contextmanager
+        def dummy_context_manager(*args, **kwargs):
+            yield
         log_file = dummy_context_manager()
 
     with log_file:

--- a/hyperspyui/__main__.py
+++ b/hyperspyui/__main__.py
@@ -72,8 +72,22 @@ def _get_logfile():
     return log_file
 
 
+def get_splash():
+    from qtpy.QtCore import Qt
+    from qtpy.QtWidgets import QApplication, QSplashScreen
+    from qtpy.QtGui import QColor, QPixmap
+    splash_pix = QPixmap(os.path.join(
+        os.path.dirname(__file__), 'images', 'splash.png'))
+    splash = QSplashScreen(splash_pix, Qt.WindowStaysOnTopHint)
+    splash.show()
+    splash.showMessage("Initializing...", Qt.AlignBottom | Qt.AlignCenter |
+                       Qt.AlignAbsolute, QColor(Qt.white))
+    QApplication.processEvents()
+    return splash
+
+
 def main():
-    from qtpy.QtCore import QCoreApplication, Qt
+    from qtpy.QtCore import QCoreApplication
     from qtpy.QtWidgets import QApplication
     from qtpy import API
 
@@ -98,18 +112,6 @@ def main():
         # Make sure we only have a single instance
         from hyperspyui.singleapplication import get_app
         app = get_app('hyperspyui')
-
-    def get_splash():
-        from qtpy.QtWidgets import QApplication, QSplashScreen
-        from qtpy.QtGui import QColor, QPixmap
-        splash_pix = QPixmap(os.path.join(
-            os.path.dirname(__file__), 'images', 'splash.png'))
-        splash = QSplashScreen(splash_pix, Qt.WindowStaysOnTopHint)
-        splash.show()
-        splash.showMessage("Initializing...", Qt.AlignBottom | Qt.AlignCenter |
-                           Qt.AlignAbsolute, QColor(Qt.white))
-        QApplication.processEvents()
-        return splash
 
     splash = get_splash()
 

--- a/hyperspyui/_elements.py
+++ b/hyperspyui/_elements.py
@@ -2,7 +2,7 @@
 """
 List of elements
 
-Data processed from wikipedia\s periodic table template page (fall 2014)
+Data processed from wikipedia's periodic table template page (fall 2014)
 """
 
 elements = [[

--- a/hyperspyui/_tools/figuretool.py
+++ b/hyperspyui/_tools/figuretool.py
@@ -22,7 +22,7 @@ Created on Sun Dec 07 01:48:00 2014
 """
 
 import collections
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 from .tool import Tool
 

--- a/hyperspyui/_tools/hometool.py
+++ b/hyperspyui/_tools/hometool.py
@@ -39,7 +39,7 @@ class HomeTool(FigureTool):
         return 'Plot'
 
     def get_icon(self):
-        return os.path.dirname(__file__) + '/../images/home.svg'
+        return os.path.join(os.path.dirname(__file__), '..', 'images', 'home.svg')
 
     def single_action(self):
         return self.home

--- a/hyperspyui/_tools/linetool.py
+++ b/hyperspyui/_tools/linetool.py
@@ -21,7 +21,7 @@ Created on Thu Jul 30 11:42:05 2015
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 import numpy as np
 
 from hyperspy.drawing.widgets import Line2DWidget, RangeWidget

--- a/hyperspyui/_tools/multiselectiontool.py
+++ b/hyperspyui/_tools/multiselectiontool.py
@@ -21,7 +21,7 @@ Created on Mon Aug 03 19:43:52 2015
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 from hyperspy.signal import BaseSignal
 from hyperspy.drawing.widgets import (RectangleWidget, RangeWidget,

--- a/hyperspyui/_tools/selectiontool.py
+++ b/hyperspyui/_tools/selectiontool.py
@@ -21,7 +21,7 @@ Created on Fri Apr 17 00:03:50 2015
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 from hyperspy.drawing.widgets import (RectangleWidget, RangeWidget,
                                       SquareWidget, VerticalLineWidget)

--- a/hyperspyui/_tools/tool.py
+++ b/hyperspyui/_tools/tool.py
@@ -21,7 +21,7 @@ Created on Sun Dec 07 03:48:36 2014
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 
 class Tool(QtCore.QObject):

--- a/hyperspyui/actionable.py
+++ b/hyperspyui/actionable.py
@@ -21,7 +21,7 @@ Created on Mon Nov 17 11:35:52 2014
 @author: Vidar Tonaas Fauske
 """
 
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtWidgets
 from collections import OrderedDict
 
 

--- a/hyperspyui/actionable.py
+++ b/hyperspyui/actionable.py
@@ -21,7 +21,7 @@ Created on Mon Nov 17 11:35:52 2014
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 from collections import OrderedDict
 
 
@@ -38,12 +38,12 @@ class Actionable(QtCore.QObject):
         self.sep_counter = 0
 
     def add_action(self, key, title, on_trig):
-        ac = QtGui.QAction(title, self)  # TODO: tr()?
+        ac = QtWidgets.QAction(title, self)  # TODO: tr()?
         self.connect(ac, QtCore.SIGNAL('triggered()'), on_trig)
         self.actions[key] = ac
 
     def add_separator(self):
         self.sep_counter += 1
-        ac = QtGui.QAction(self)
+        ac = QtWidgets.QAction(self)
         ac.setSeparator(True)
         self.actions[self.sep_counter] = ac

--- a/hyperspyui/actionable.py
+++ b/hyperspyui/actionable.py
@@ -39,7 +39,7 @@ class Actionable(QtCore.QObject):
 
     def add_action(self, key, title, on_trig):
         ac = QtWidgets.QAction(title, self)  # TODO: tr()?
-        self.connect(ac, QtCore.SIGNAL('triggered()'), on_trig)
+        ac.triggered.connect(on_trig)
         self.actions[key] = ac
 
     def add_separator(self):

--- a/hyperspyui/advancedaction.py
+++ b/hyperspyui/advancedaction.py
@@ -22,7 +22,7 @@ Created on Sun Aug 21 19:59:04 2016
 """
 
 
-from qtpy import QtGui, QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 
 # QAction.trigger/activate are not virtual, so cannot simply override.
@@ -33,6 +33,7 @@ class AdvancedAction(QtWidgets.QAction):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # not working on pyside, not tested on pyside2 because of pyface issue
         super().triggered[bool].connect(self._trigger)
 
     @property

--- a/hyperspyui/advancedaction.py
+++ b/hyperspyui/advancedaction.py
@@ -22,12 +22,12 @@ Created on Sun Aug 21 19:59:04 2016
 """
 
 
-from python_qt_binding import QtGui, QtCore
+from qtpy import QtGui, QtCore, QtWidgets
 
 
 # QAction.trigger/activate are not virtual, so cannot simply override.
 # Instead, we shadow/wrap the triggered signal used by our python code
-class AdvancedAction(QtGui.QAction):
+class AdvancedAction(QtWidgets.QAction):
     # The overloaded signal can take an optional argument `advanced`
     _triggered = QtCore.Signal([], [bool], [bool, bool])
 
@@ -40,10 +40,10 @@ class AdvancedAction(QtGui.QAction):
         return self._triggered
 
     def _trigger(self, checked):
-        mods = QtGui.QApplication.keyboardModifiers()
+        mods = QtWidgets.QApplication.keyboardModifiers()
         advanced = mods & QtCore.Qt.AltModifier == QtCore.Qt.AltModifier
         self._triggered[bool, bool].emit(checked, advanced)
         self._triggered[bool].emit(checked)
         self._triggered.emit()
 
-AdvancedAction.__init__.__doc__ = QtGui.QAction.__init__.__doc__
+AdvancedAction.__init__.__doc__ = QtWidgets.QAction.__init__.__doc__

--- a/hyperspyui/bindinglist.py
+++ b/hyperspyui/bindinglist.py
@@ -22,9 +22,9 @@ Created on Mon Oct 27 23:17:25 2014
 """
 
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 
 class BindingList(list):

--- a/hyperspyui/bindinglist.py
+++ b/hyperspyui/bindinglist.py
@@ -22,9 +22,7 @@ Created on Mon Oct 27 23:17:25 2014
 """
 
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtWidgets
 
 
 class BindingList(list):
@@ -62,7 +60,7 @@ class BindingList(list):
 #            cb = {'ap': target.append, 'in': target.insert,
 #                  'ex': target.append, 're': target.removeOne,
 #                  'po': target.removeAt}
-        elif isinstance(target, QListWidget):
+        elif isinstance(target, QtWidgets.QListWidget):
             def qlr(value):
                 target.takeItem(self.index(value))
             cb = {'ap': target.addItem, 'in': target.insertItem,

--- a/hyperspyui/images/testing_icon_coloring.py
+++ b/hyperspyui/images/testing_icon_coloring.py
@@ -17,6 +17,8 @@ last edited: September 2011
 
 import sys
 from qtpy import QtGui, QtWidgets
+from qtpy.QtGui import QPalette
+
 import tempfile
 import glob
 import os

--- a/hyperspyui/images/testing_icon_coloring.py
+++ b/hyperspyui/images/testing_icon_coloring.py
@@ -17,14 +17,13 @@ last edited: September 2011
 
 import sys
 from qtpy import QtGui, QtWidgets
-from qtpy.QtGui import QPalette
 
 import tempfile
 import glob
 import os
 
 
-class Example(QtGui.QMainWindow):
+class Example(QtWidgets.QMainWindow):
 
     def __init__(self):
         super(Example, self).__init__()
@@ -39,14 +38,14 @@ class Example(QtGui.QMainWindow):
         svg_file = open(filename, 'r')
         svg_cnt = svg_file.read()
         temp = tempfile.NamedTemporaryFile(delete=False)
-        temp.write(svg_cnt.replace(oldColor, newColor))
+        temp.write(svg_cnt.replace(oldColor, newColor).encode('utf-8'))
         temp.close()
 
         return temp.name
 
     def initUI(self):
-        stack = QtGui.QVBoxLayout()
-        widget = QtGui.QWidget()
+        stack = QtWidgets.QVBoxLayout()
+        widget = QtWidgets.QWidget()
 
         color_list = []
         color_list.append(('QtGui.QPalette.Window',
@@ -74,14 +73,13 @@ class Example(QtGui.QMainWindow):
         color_list.append(('QtGui.QPalette.BrightText',
                            self.palette().color(QtGui.QPalette.BrightText)))
 
-        textEdit = QtGui.QTextEdit()
+        textEdit = QtWidgets.QTextEdit()
         for n, c in color_list:
             textEdit.append(n + ':\t' + str(c.name()))
         stack.addWidget(textEdit)
 
         # Change this to wherever your icons are stored
-        icon_files = glob.glob("D:/UMD_Research/Software/hyperspyUI/"
-                               "hyperspyui/images/*.svg")
+        icon_files = glob.glob("*.svg")
 
         widget.setLayout(stack)
         self.setCentralWidget(widget)

--- a/hyperspyui/images/testing_icon_coloring.py
+++ b/hyperspyui/images/testing_icon_coloring.py
@@ -16,7 +16,7 @@ last edited: September 2011
 """
 
 import sys
-from PyQt4 import QtGui
+from qtpy import QtGui, QtWidgets
 import tempfile
 import glob
 import os
@@ -94,7 +94,7 @@ class Example(QtGui.QMainWindow):
             ico_list[i] = QtGui.QIcon(self.replaceSvgColor(f,
                                                            '#000000',
                                                            'red'))
-            action_list[i] = QtGui.QAction(ico_list[i], 'Exit', self)
+            action_list[i] = QtWidgets.QAction(ico_list[i], 'Exit', self)
             action_list[i].setStatusTip(os.path.basename(f))
 
             # add to toolbars
@@ -126,7 +126,7 @@ class Example(QtGui.QMainWindow):
 
 
 def main():
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     _ = Example()
     sys.exit(app.exec_())
 

--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -42,9 +42,9 @@ from hyperspyui.widgets.pickxsignals import PickXSignalsWidget
 from hyperspyui.log import logger
 import hyperspyui.tools
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 import hyperspy.utils.plot
 import hyperspy.signals
@@ -193,7 +193,7 @@ class MainWindow(MainWindowHyperspy):
                         tip="Open the HyperSpyUI documentation in a browser.")
 
         # --- Add signal type selection actions ---
-        signal_type_ag = QActionGroup(self)
+        signal_type_ag = QtWidgets.QActionGroup(self)
         signal_type_ag.setExclusive(True)
         for st in self.signal_types.keys():
             f = partial(self.set_signal_type, st)
@@ -203,7 +203,7 @@ class MainWindow(MainWindowHyperspy):
         self.signal_type_ag = signal_type_ag
 
         # --- Add signal data type selection actions ---
-        signal_datatype_ag = QActionGroup(self)
+        signal_datatype_ag = QtWidgets.QActionGroup(self)
         signal_datatype_ag.setExclusive(True)
         import numpy as np
         for t in [np.bool, np.bool8, np.byte, np.complex, np.complex64,

--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -83,7 +83,7 @@ class MainWindow(MainWindowHyperspy):
 
         # Set window icon
         self.setWindowIcon(QtGui.QIcon(os.path.join(os.path.dirname(__file__),
-                                       'images', 'hyperspy.svg')))
+                                                    'images', 'hyperspy.svg')))
 
         # Parse any command line options
         self.parse_args(argv)
@@ -105,6 +105,9 @@ class MainWindow(MainWindowHyperspy):
         # Set the UI in front of other applications
         self.show()
         self.raise_()
+        # Workaround to bring the floating console to the front with pyqt5
+        if self._console_dock.isFloating():
+            self._console_dock.setFloating(True)
 
     def handleSecondInstance(self, argv):
         """

--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -43,8 +43,7 @@ from hyperspyui.log import logger
 import hyperspyui.tools
 
 from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy.QtCore import Qt
 
 import hyperspy.utils.plot
 import hyperspy.signals
@@ -72,7 +71,7 @@ class MainWindow(MainWindowHyperspy):
          ('Dielectric Function', hyperspy.signals.DielectricFunction),
          ])
 
-    load_complete = Signal()
+    load_complete = QtCore.Signal()
 
     def __init__(self, parent=None, argv=None):
         # State variables
@@ -83,8 +82,8 @@ class MainWindow(MainWindowHyperspy):
         super(MainWindow, self).__init__(parent)
 
         # Set window icon
-        self.setWindowIcon(QIcon(os.path.dirname(__file__) +
-                                 '/images/hyperspy.svg'))
+        self.setWindowIcon(QtGui.QIcon(os.path.join(os.path.dirname(__file__),
+                                       'images', 'hyperspy.svg')))
 
         # Parse any command line options
         self.parse_args(argv)
@@ -122,8 +121,8 @@ class MainWindow(MainWindowHyperspy):
         'argv'.
         """
         parser = argparse.ArgumentParser(
-            description=QCoreApplication.applicationName() +
-            " " + QCoreApplication.applicationVersion())
+            description=QtCore.QCoreApplication.applicationName() +
+            " " + QtCore.QCoreApplication.applicationVersion())
         parser.add_argument('files', metavar='file', type=str, nargs='*',
                             help='data file to open.')
         if argv is None:
@@ -140,33 +139,33 @@ class MainWindow(MainWindowHyperspy):
 
         # Files:
         self.add_action('open', "&Open", self.load,
-                        shortcut=QKeySequence.Open,
+                        shortcut=QtGui.QKeySequence.Open,
                         icon='open.svg',
                         tip="Open existing file(s)")
         self.add_action('open_stack', "Open S&tack", self.load_stack,
                         tip="Open files and combine into one signal (stacked)")
         self.add_action('close', "&Close", self.close_signal,
-                        shortcut=QKeySequence.Close,
+                        shortcut=QtGui.QKeySequence.Close,
                         icon='close_window.svg',
                         selection_callback=self.select_signal,
                         tip="Close the selected signal(s)")
         self.add_action('new_editor', "&New editor", self.new_editor,
-                        shortcut=QKeySequence.New,
+                        shortcut=QtGui.QKeySequence.New,
                         tip="Opens a new code editor")
 
-        close_all_key = QKeySequence(Qt.CTRL + Qt.ALT + Qt.Key_F4,
-                                     Qt.CTRL + Qt.ALT + Qt.Key_W)
+        close_all_key = QtGui.QKeySequence(Qt.CTRL + Qt.ALT + Qt.Key_F4,
+                                           Qt.CTRL + Qt.ALT + Qt.Key_W)
         self.add_action('close_all', "&Close All", self.close_all_signals,
                         shortcut=close_all_key,
                         icon='close_windows.svg',
                         tip="Close all signals")
         self.add_action('exit', "E&xit", self.close,
-                        shortcut=QKeySequence.Quit,
+                        shortcut=QtGui.QKeySequence.Quit,
                         tip="Exits the application")
 
         # I/O:
         self.add_action('save', "&Save", self.save,
-                        shortcut=QKeySequence.Save,
+                        shortcut=QtGui.QKeySequence.Save,
                         icon='save.svg',
                         selection_callback=self.select_signal,
                         tip="Save the selected signal(s)")
@@ -364,7 +363,7 @@ class MainWindow(MainWindowHyperspy):
                                titles=titles, wrap_col=wrap_col)
         diag = self.show_okcancel_dialog("Select signals", w, True)
         signals = None
-        if diag.result() == QDialog.Accepted:
+        if diag.result() == QtWidgets.QDialog.Accepted:
             signals = w.get_selected()
         w.unbind()
         return signals

--- a/hyperspyui/mainwindow.py
+++ b/hyperspyui/mainwindow.py
@@ -39,19 +39,8 @@ except ValueError:
     if 'sphinx' not in sys.modules:
         raise
 
-from qtpy import QtGui
-from qtpy.QtWidgets import QApplication, QSplashScreen
-from qtpy.QtGui import QColor, QPixmap
+from qtpy import QtGui, QtCore, QtWidgets
 from qtpy.QtCore import Qt
-splash_pix = QPixmap(os.path.join(
-    os.path.dirname(__file__), 'images', 'splash.png'))
-SPLASH = QSplashScreen(splash_pix, Qt.WindowStaysOnTopHint)
-SPLASH.show()
-SPLASH.showMessage("Initializing...", Qt.AlignBottom | Qt.AlignCenter |
-                   Qt.AlignAbsolute, QColor(Qt.white))
-QApplication.processEvents()
-
-from qtpy import QtCore, QtWidgets
 
 from hyperspyui.mainwindowhyperspy import MainWindowHyperspy, tr
 from hyperspyui.util import create_add_component_actions, win2sig, dict_rlu
@@ -75,8 +64,8 @@ class MainWindow(MainWindowHyperspy):
 
     load_complete = QtCore.Signal()
 
-    def __init__(self, parent=None, argv=None):
-        self.splash = SPLASH
+    def __init__(self, splash, parent=None, argv=None):
+        self.splash = splash
 
         # State variables
         self.signal_type_ag = None
@@ -85,7 +74,6 @@ class MainWindow(MainWindowHyperspy):
 
         self._load_signal_types()
 
-        print('here')
         super(MainWindow, self).__init__(parent)
 
         # Set window icon
@@ -124,8 +112,8 @@ class MainWindow(MainWindowHyperspy):
             logger.debug(message)
         self.splash.show()
         self.splash.showMessage(message, Qt.AlignBottom | Qt.AlignCenter |
-                                Qt.AlignAbsolute, QColor(Qt.white))
-        QApplication.processEvents()
+                                Qt.AlignAbsolute, QtGui.QColor(Qt.white))
+        QtWidgets.QApplication.processEvents()
 
     def _load_signal_types(self):
         self.set_splash('Loading HyperSpy signals...')

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -31,7 +31,7 @@ import warnings
 import sys
 
 from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import Qt, SIGNAL
+from qtpy.QtCore import Qt
 
 from .widgets.consolewidget import ConsoleWidget
 import hyperspyui.mdi_mpl_backend
@@ -274,38 +274,33 @@ class MainWindowBase(QtWidgets.QMainWindow):
         ac_nested.setStatusTip(tr("Allow nested widget docking"))
         ac_nested.setCheckable(True)
         ac_nested.setChecked(self.isDockNestingEnabled())
-        self.connect(ac_nested, SIGNAL('triggered(bool)'),
-                     self.setDockNestingEnabled)
+        ac_nested.triggered[bool].connect(self.setDockNestingEnabled)
         self.actions['nested_docking'] = ac_nested
 
         # Tile windows action
         ac_tile = QtWidgets.QAction(tr("Tile"), self)
         ac_tile.setStatusTip(tr("Arranges all figures in a tile pattern"))
-        self.connect(ac_tile, SIGNAL('triggered()'),
-                     self.main_frame.tileSubWindows)
+        ac_tile.triggered.connect(self.main_frame.tileSubWindows)
         self.actions['tile_windows'] = ac_tile
 
         # Cascade windows action
         ac_cascade = QtWidgets.QAction(tr("Cascade"), self)
         ac_cascade.setStatusTip(
             tr("Arranges all figures in a cascade pattern"))
-        self.connect(ac_cascade, SIGNAL('triggered()'),
-                     self.main_frame.cascadeSubWindows)
+        ac_cascade.triggered.connect(self.main_frame.cascadeSubWindows)
         self.actions['cascade_windows'] = ac_cascade
 
         # Close all figures action
         ac_close_figs = QtWidgets.QAction(tr("Close all"), self)
         ac_close_figs.setStatusTip(tr("Closes all matplotlib figures"))
-        self.connect(ac_close_figs, SIGNAL('triggered()'),
-                     lambda: matplotlib.pyplot.close("all"))
+        ac_close_figs.triggered.connect(lambda: matplotlib.pyplot.close("all"))
         self.actions['close_all_windows'] = ac_close_figs
 
         # Reset geometry action
         ac_reset_layout = QtWidgets.QAction(tr("Reset layout"), self)
         ac_reset_layout.setStatusTip(tr("Resets layout of toolbars and "
                                         "widgets"))
-        self.connect(ac_reset_layout, SIGNAL('triggered()'),
-                     self.reset_geometry)
+        ac_reset_layout.triggered.connect(self.reset_geometry)
         self.actions['reset_layout'] = ac_reset_layout
 
     def create_menu(self):

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -31,6 +31,7 @@ import sys
 
 from hyperspyui.exceptions import ProcessCanceled
 from hyperspyui.log import logger
+from hyperspyui.widgets.consolewidget import ConsoleWidget
 
 from qtpy import QtCore, QtWidgets, API
 from qtpy.QtCore import Qt
@@ -445,7 +446,6 @@ class MainWindowBase(QtWidgets.QMainWindow):
         # We could inherit QAction, and have it reroute when it triggers,
         # and then drop route when it finishes, however this will not catch
         # interactive dialogs and such.
-        from .widgets.consolewidget import ConsoleWidget
         c = self._get_console_config()
         self.settings.set_default('console_completion_type', 'droplist')
         valid_completions = ConsoleWidget.gui_completion.values

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -29,11 +29,9 @@ matplotlib.interactive(True)
 import os
 import warnings
 import sys
-import logging
 
-from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Qt, SIGNAL
 
 from .widgets.consolewidget import ConsoleWidget
 import hyperspyui.mdi_mpl_backend
@@ -53,7 +51,7 @@ sys.excepthook = myexcepthook
 
 
 def tr(text):
-    return QCoreApplication.translate("MainWindow", text)
+    return QtCore.QCoreApplication.translate("MainWindow", text)
 
 
 def lowpriority():
@@ -181,7 +179,7 @@ class MainWindowBase(QtWidgets.QMainWindow):
     def toolbar_button_size(self, value):
         self.settings['toolbar_button_size'] = value
         self.setIconSize(
-            QSize(self.toolbar_button_size, self.toolbar_button_size))
+            QtCore.QSize(self.toolbar_button_size, self.toolbar_button_size))
 
     @property
     def cur_dir(self):
@@ -209,8 +207,8 @@ class MainWindowBase(QtWidgets.QMainWindow):
 
     def handleSecondInstance(self, argv):
         # overload if needed
-        self.setWindowState(self.windowState() & ~QtCore.Qt.WindowMinimized |
-                            QtCore.Qt.WindowActive)
+        self.setWindowState(self.windowState() & ~Qt.WindowMinimized |
+                            Qt.WindowActive)
         self.activateWindow()
 
     def closeEvent(self, event):
@@ -231,8 +229,8 @@ class MainWindowBase(QtWidgets.QMainWindow):
 
     def create_ui(self):
         self.setIconSize(
-            QSize(self.toolbar_button_size, self.toolbar_button_size))
-        self.main_frame = QMdiArea()
+            QtCore.QSize(self.toolbar_button_size, self.toolbar_button_size))
+        self.main_frame = QtWidgets.QMdiArea()
 
         self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
         self.setCorner(Qt.TopLeftCorner, Qt.LeftDockWidgetArea)
@@ -471,7 +469,7 @@ class MainWindowBase(QtWidgets.QMainWindow):
 
         self.console = control
 
-        self._console_dock = QDockWidget()
+        self._console_dock = QtWidgets.QDockWidget()
         self._console_dock.setObjectName('console_widget')
         self._console_dock.setWidget(control)
         self._console_dock.setWindowTitle("Console")

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -464,8 +464,7 @@ class MainWindowBase(QtWidgets.QMainWindow):
 
         self.console = control
 
-        self._console_dock = QtWidgets.QDockWidget()
+        self._console_dock = QtWidgets.QDockWidget("Console")
         self._console_dock.setObjectName('console_widget')
         self._console_dock.setWidget(control)
-        self._console_dock.setWindowTitle("Console")
         self.addDockWidget(Qt.BottomDockWidgetArea, self._console_dock)

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -33,7 +33,7 @@ import sys
 from hyperspyui.exceptions import ProcessCanceled
 from hyperspyui.log import logger
 
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets, API
 from qtpy.QtCore import Qt
 
 
@@ -370,6 +370,17 @@ class MainWindowBase(QtWidgets.QMainWindow):
                     self.active_tool.get_name(), e))
         self.active_tool = tool
         tool.connect_windows(self.figures)
+
+    def setUpdatesEnabled(self, value, force_setting=False):
+        """
+        pyqt5 doesn't seem to suffer from screen flickering and it is not 
+        necessary to disable and enable updating. Better to leave the update on
+        for plotting purposes.
+        """
+        if API == 'pyqt5':
+            return
+        else:
+            super(MainWindowBase, self).setUpdatesEnabled(value)
 
     # --------- Figure management ---------
 

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -26,7 +26,6 @@ import matplotlib
 matplotlib.use('module://hyperspyui.mdi_mpl_backend')
 matplotlib.interactive(True)
 
-import os
 import warnings
 import sys
 
@@ -371,17 +370,6 @@ class MainWindowBase(QtWidgets.QMainWindow):
         self.active_tool = tool
         tool.connect_windows(self.figures)
 
-    def setUpdatesEnabled(self, value, force_setting=False):
-        """
-        pyqt5 doesn't seem to suffer from screen flickering and it is not 
-        necessary to disable and enable updating. Better to leave the update on
-        for plotting purposes.
-        """
-        if API == 'pyqt5':
-            return
-        else:
-            super(MainWindowBase, self).setUpdatesEnabled(value)
-
     # --------- Figure management ---------
 
     # --------- MPL Events ---------
@@ -416,7 +404,7 @@ class MainWindowBase(QtWidgets.QMainWindow):
     # --------- End MPL Events ---------
 
     def on_subwin_activated(self, mdi_figure):
-        if mdi_figure and os.environ['QT_API'] == 'pyside':
+        if mdi_figure and API == 'pyside':
             mdi_figure.activateAction().setChecked(True)
         self.check_action_selections(mdi_figure)
 

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -31,9 +31,9 @@ import warnings
 import sys
 import logging
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from .widgets.consolewidget import ConsoleWidget
 import hyperspyui.mdi_mpl_backend
@@ -107,7 +107,7 @@ def normalpriority():
         os.nice(-os.nice(0))
 
 
-class MainWindowBase(QMainWindow):
+class MainWindowBase(QtWidgets.QMainWindow):
 
     """
     Base layer in application stack. Should handle the connection to our custom
@@ -268,11 +268,11 @@ class MainWindowBase(QMainWindow):
         logger.debug("Creating plugin actions")
         self.plugin_manager.create_actions()
 
-        self.selectable_tools = QActionGroup(self)
+        self.selectable_tools = QtWidgets.QActionGroup(self)
         self.selectable_tools.setExclusive(True)
 
         # Nested docking action
-        ac_nested = QAction(tr("Nested docking"), self)
+        ac_nested = QtWidgets.QAction(tr("Nested docking"), self)
         ac_nested.setStatusTip(tr("Allow nested widget docking"))
         ac_nested.setCheckable(True)
         ac_nested.setChecked(self.isDockNestingEnabled())
@@ -281,14 +281,14 @@ class MainWindowBase(QMainWindow):
         self.actions['nested_docking'] = ac_nested
 
         # Tile windows action
-        ac_tile = QAction(tr("Tile"), self)
+        ac_tile = QtWidgets.QAction(tr("Tile"), self)
         ac_tile.setStatusTip(tr("Arranges all figures in a tile pattern"))
         self.connect(ac_tile, SIGNAL('triggered()'),
                      self.main_frame.tileSubWindows)
         self.actions['tile_windows'] = ac_tile
 
         # Cascade windows action
-        ac_cascade = QAction(tr("Cascade"), self)
+        ac_cascade = QtWidgets.QAction(tr("Cascade"), self)
         ac_cascade.setStatusTip(
             tr("Arranges all figures in a cascade pattern"))
         self.connect(ac_cascade, SIGNAL('triggered()'),
@@ -296,14 +296,14 @@ class MainWindowBase(QMainWindow):
         self.actions['cascade_windows'] = ac_cascade
 
         # Close all figures action
-        ac_close_figs = QAction(tr("Close all"), self)
+        ac_close_figs = QtWidgets.QAction(tr("Close all"), self)
         ac_close_figs.setStatusTip(tr("Closes all matplotlib figures"))
         self.connect(ac_close_figs, SIGNAL('triggered()'),
                      lambda: matplotlib.pyplot.close("all"))
         self.actions['close_all_windows'] = ac_close_figs
 
         # Reset geometry action
-        ac_reset_layout = QAction(tr("Reset layout"), self)
+        ac_reset_layout = QtWidgets.QAction(tr("Reset layout"), self)
         ac_reset_layout.setStatusTip(tr("Resets layout of toolbars and "
                                         "widgets"))
         self.connect(ac_reset_layout, SIGNAL('triggered()'),

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -131,20 +131,10 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
         # Connect UIProgressBar for graphical hyperspy progress
         s = uiprogressbar.signaler
-#        s.created.connect(self.on_progressbar_wanted)
-#        s.created[int, int, str].connect(self.on_progressbar_wanted)
-#        s.connect(s, Signal('created(int, int, QString)'),
-#                  self.on_progressbar_wanted)
-#        s.progress[int, int].connect(self.on_progressbar_update)
-#        s.connect(s, Signal('progress(int, int)'),
-#                  self.on_progressbar_update)
-#        s.progress[int, int, str].connect(self.on_progressbar_update)
-#        s.connect(s, Signal('progress(int, int, QString)'),
-#                  self.on_progressbar_update)
-#        s.finished[int].connect(self.on_progressbar_finished)
-#        s.connect(s, Signal('finished(int)'),
-#                  self.on_progressbar_finished)
-#        self.cancel_progressbar.connect(s.on_cancel)
+        s.created[int, int, str].connect(self.on_progressbar_wanted)
+        s.progress[int, int, str].connect(self.on_progressbar_update)
+        s.finished[int].connect(self.on_progressbar_finished)
+        self.cancel_progressbar.connect(s.on_cancel)
 
         # Connect to Signal.plot events
         hooksignal.connect_plotting(self.on_signal_plotting)
@@ -597,7 +587,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
     def get_signal_filepath_suggestion(self, signal, default_ext=None):
         if default_ext is None:
             default_ext = hyperspy.defaults_parser.preferences.General.\
-                         default_file_format
+                default_file_format
         # Get initial suggestion for save dialog.  Use
         # original_filename metadata if present, or self.cur_dir if not
         if signal.signal.metadata.has_item('General.original_filename'):
@@ -663,7 +653,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
             progressbar = self.progressbars[pid]
             progressbar.setValue(0)
         else:
-            progressbar = QtCore.QProgressDialog(self)
+            progressbar = QtWidgets.QProgressDialog(self)
             progressbar.setMinimumDuration(2000)
             progressbar.setMinimum(0)
         progressbar.setMaximum(maxval)

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -608,7 +608,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
         fn = signal.name
         if os.name == 'nt':
             fn = fn.replace("<", "[").replace(">", "]")
-            fn = re.sub("[:\"|\?\*]", '', fn)
+            fn = re.sub(r"[:\"|\?\*]", '', fn)
         # Build suggestion and return
         path_suggestion = os.path.sep.join((base, fn))
         path_suggestion = os.path.extsep.join((path_suggestion, ext))

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -126,6 +126,10 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
         self.create_statusbar()
 
+        # Disable hyperspy_ipywidgets_gui
+        if hyperspy.api.preferences.GUIs.enable_ipywidgets_gui:
+            hyperspy.api.preferences.GUIs.enable_ipywidgets_gui = False
+
         # Enable drag and drop
         self.setAcceptDrops(True)
 

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -45,9 +45,9 @@ uiprogressbar.takeover_progressbar()    # Enable hooks
 from . import hooksignal
 hooksignal.hook_signal()
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 from hyperspyui.signalwrapper import SignalWrapper
 from hyperspyui.bindinglist import BindingList
 from hyperspyui.log import logger

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -689,7 +689,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
     def on_console_executing(self, source):
         super(MainWindowHyperspy, self).on_console_executing(source)
-#        self.setUpdatesEnabled(False)
+        self.setUpdatesEnabled(False)
         for s in self.signals:
             s.keep_on_close = True
 
@@ -698,7 +698,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
         for s in self.signals:
             s.update_figures()
             s.keep_on_close = False
-#        self.setUpdatesEnabled(True)
+        self.setUpdatesEnabled(True)
 
     def _get_console_exec(self):
         ex = super(MainWindowHyperspy, self)._get_console_exec()

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -25,7 +25,6 @@ import os
 import gc
 import re
 import numpy as np
-import logging
 import warnings
 import traceback
 import sys
@@ -45,9 +44,10 @@ uiprogressbar.takeover_progressbar()    # Enable hooks
 from . import hooksignal
 hooksignal.hook_signal()
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import SIGNAL
+from qtpy.QtWidgets import QMessageBox, QLabel
+
 from hyperspyui.signalwrapper import SignalWrapper
 from hyperspyui.bindinglist import BindingList
 from hyperspyui.log import logger
@@ -67,14 +67,14 @@ overrides.override_hyperspy()           # Enable hyperspy overrides
 glob_escape = re.compile(r'([\[\]])')
 
 
-class TrackEventFilter(QObject):
+class TrackEventFilter(QtCore.QObject):
     """Qt Event filter for tracking the mouse position in the application.
     """
 
-    track = Signal(QPoint)
+    track = SIGNAL(QtCore.QPoint)
 
     def eventFilter(self, receiver, event):
-        if(event.type() == QEvent.MouseMove):
+        if(event.type() == QtCore.QEvent.MouseMove):
             self.track.emit(event.globalPos())
         # Call Base Class Method to Continue Normal Event Processing
         return False
@@ -153,7 +153,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
         Trigger a GC one second after calling this.
         """
         del removed
-        QTimer.singleShot(1000, gc.collect)
+        QtCore.QTimer.singleShot(1000, gc.collect)
 
     def create_widgetbar(self):
         # Add DataViewWidget to widget bar:
@@ -195,7 +195,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
         # position with an event filter
         self.main_frame.subWindowActivated.connect(
             self._connect_figure_2_statusbar)
-        app = QApplication.instance()
+        app = QtWidgets.QApplication.instance()
         self.tracker = TrackEventFilter()
         self.tracker.track.connect(self._on_track)
         app.installEventFilter(self.tracker)
@@ -650,7 +650,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
     # --------- Hyperspy progress bars ----------
 
-    cancel_progressbar = Signal(int)
+    cancel_progressbar = SIGNAL(int)
 
     def on_progressbar_wanted(self, pid, maxval, label):
         logger.debug("Progressbar wanted. ID: %d", pid)
@@ -658,7 +658,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
             progressbar = self.progressbars[pid]
             progressbar.setValue(0)
         else:
-            progressbar = QProgressDialog(self)
+            progressbar = QtCore.QProgressDialog(self)
             progressbar.setMinimumDuration(2000)
             progressbar.setMinimum(0)
         progressbar.setMaximum(maxval)
@@ -674,7 +674,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
                     self.cancel_progressbar.emit(pid)
 
             progressbar.canceled.connect(cancel)
-            progressbar.setWindowModality(Qt.WindowModal)
+            progressbar.setWindowModality(QtCore.Qt.WindowModal)
 
             self.progressbars[pid] = progressbar
 

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -116,10 +116,6 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
         self.create_statusbar()
 
-        # Disable hyperspy_ipywidgets_gui
-        if hyperspy.api.preferences.GUIs.enable_ipywidgets_gui:
-            hyperspy.api.preferences.GUIs.enable_ipywidgets_gui = False
-
         # Enable drag and drop
         self.setAcceptDrops(True)
 

--- a/hyperspyui/mainwindowhyperspy.py
+++ b/hyperspyui/mainwindowhyperspy.py
@@ -45,7 +45,7 @@ from . import hooksignal
 hooksignal.hook_signal()
 
 from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import SIGNAL
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox, QLabel
 
 from hyperspyui.signalwrapper import SignalWrapper
@@ -71,7 +71,7 @@ class TrackEventFilter(QtCore.QObject):
     """Qt Event filter for tracking the mouse position in the application.
     """
 
-    track = SIGNAL(QtCore.QPoint)
+    track = Signal(QtCore.QPoint)
 
     def eventFilter(self, receiver, event):
         if(event.type() == QtCore.QEvent.MouseMove):
@@ -131,15 +131,20 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
         # Connect UIProgressBar for graphical hyperspy progress
         s = uiprogressbar.signaler
-        s.connect(s, SIGNAL('created(int, int, QString)'),
-                  self.on_progressbar_wanted)
-        s.connect(s, SIGNAL('progress(int, int)'),
-                  self.on_progressbar_update)
-        s.connect(s, SIGNAL('progress(int, int, QString)'),
-                  self.on_progressbar_update)
-        s.connect(s, SIGNAL('finished(int)'),
-                  self.on_progressbar_finished)
-        self.cancel_progressbar.connect(s.on_cancel)
+#        s.created.connect(self.on_progressbar_wanted)
+#        s.created[int, int, str].connect(self.on_progressbar_wanted)
+#        s.connect(s, Signal('created(int, int, QString)'),
+#                  self.on_progressbar_wanted)
+#        s.progress[int, int].connect(self.on_progressbar_update)
+#        s.connect(s, Signal('progress(int, int)'),
+#                  self.on_progressbar_update)
+#        s.progress[int, int, str].connect(self.on_progressbar_update)
+#        s.connect(s, Signal('progress(int, int, QString)'),
+#                  self.on_progressbar_update)
+#        s.finished[int].connect(self.on_progressbar_finished)
+#        s.connect(s, Signal('finished(int)'),
+#                  self.on_progressbar_finished)
+#        self.cancel_progressbar.connect(s.on_cancel)
 
         # Connect to Signal.plot events
         hooksignal.connect_plotting(self.on_signal_plotting)
@@ -650,7 +655,7 @@ class MainWindowHyperspy(MainWindowActionRecorder):
 
     # --------- Hyperspy progress bars ----------
 
-    cancel_progressbar = SIGNAL(int)
+    cancel_progressbar = Signal(int)
 
     def on_progressbar_wanted(self, pid, maxval, label):
         logger.debug("Progressbar wanted. ID: %d", pid)

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -27,9 +27,9 @@ import os
 import inspect
 from functools import partial
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.smartcolorsvgiconengine import SmartColorSVGIconEngine
 from hyperspyui.advancedaction import AdvancedAction
@@ -155,7 +155,7 @@ class MainWindowUtils(MainWindowBase):
             self.addToolBar(Qt.LeftToolBarArea, tb)
             self.toolbars[category] = tb
 
-        if not isinstance(action, QAction):
+        if not isinstance(action, QtWidgets.QAction):
             action = self.actions[action]
         tb.addAction(action)
 
@@ -186,7 +186,7 @@ class MainWindowUtils(MainWindowBase):
                 self.menuBar().insertMenu(self.windowmenu.menuAction(), m)
             self.menus[category] = m
 
-        if not isinstance(action, QAction):
+        if not isinstance(action, QtWidgets.QAction):
             action = self.actions[action]
         m.addAction(action)
 

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -238,7 +238,7 @@ class MainWindowUtils(MainWindowBase):
     def add_widget(self, widget, floating=None):
         """
         Add the passed 'widget' to the main window. If the widget is not a
-        QDockWidget, it will be wrapped in one. The QDockWidget is returned.
+        QDockWidget, it will be wrapped into one. The QDockWidget is returned.
         The widget is also added to the window menu self.windowmenu, so that
         it's visibility can be toggled.
 

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -28,8 +28,8 @@ import inspect
 from functools import partial
 
 from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QDialogButtonBox
 
 from hyperspyui.smartcolorsvgiconengine import SmartColorSVGIconEngine
 from hyperspyui.advancedaction import AdvancedAction
@@ -150,7 +150,7 @@ class MainWindowUtils(MainWindowBase):
         if category in self.toolbars:
             tb = self.toolbars[category]
         else:
-            tb = QToolBar(tr(category) + tr(" toolbar"), self)
+            tb = QtWidgets.QToolBar(tr(category) + tr(" toolbar"), self)
             tb.setObjectName(category + "_toolbar")
             self.addToolBar(Qt.LeftToolBarArea, tb)
             self.toolbars[category] = tb
@@ -182,7 +182,7 @@ class MainWindowUtils(MainWindowBase):
             if self.windowmenu is None:
                 m = self.menuBar().addMenu(label)
             else:
-                m = QMenu(label)
+                m = QtWidgets.QMenu(label)
                 self.menuBar().insertMenu(self.windowmenu.menuAction(), m)
             self.menus[category] = m
 
@@ -248,10 +248,10 @@ class MainWindowUtils(MainWindowBase):
         """
         if floating is None:
             floating = self.settings['default_widget_floating', bool]
-        if isinstance(widget, QDockWidget):
+        if isinstance(widget, QtWidgets.QDockWidget):
             d = widget
         else:
-            d = QDockWidget(self)
+            d = QtWidgets.QDockWidget(self)
             d.setWidget(widget)
             d.setWindowTitle(widget.windowTitle())
         if not d.objectName():
@@ -282,7 +282,7 @@ class MainWindowUtils(MainWindowBase):
                 current palette. If a QIcon is passed directly, it is also
                 sent through `SmartColorSVGIconEngine`.
         """
-        if not isinstance(icon, QIcon):
+        if not isinstance(icon, QtGui.QIcon):
             if isinstance(icon, str) and not os.path.isfile(icon):
                 sugg = os.path.dirname(__file__) + '/images/' + icon
                 if os.path.isfile(sugg):
@@ -293,12 +293,12 @@ class MainWindowUtils(MainWindowBase):
                     icon.endswith('svg.gz')):
                 ie = SmartColorSVGIconEngine()
                 path = icon
-                icon = QIcon(ie)
+                icon = QtGui.QIcon(ie)
                 icon.addFile(path)
             else:
-                icon = QIcon(icon)
+                icon = QtGui.QIcon(icon)
         else:
-            icon = QIcon(SmartColorSVGIconEngine(icon))
+            icon = QtGui.QIcon(SmartColorSVGIconEngine(icon))
         return icon
 
     def prompt_files(self, extension_filter=None, path=None, exists=True,
@@ -310,11 +310,11 @@ class MainWindowUtils(MainWindowBase):
             def_filter = extension_filter.split(';;', maxsplit=1)[0]
 
         if exists:
-            filenames = QFileDialog.getOpenFileNames(
+            filenames = QtWidgets.QFileDialog.getOpenFileNames(
                 self, title, path, extension_filter)
         else:
 
-            filenames = QFileDialog.getSaveFileName(
+            filenames = QtWidgets.QFileDialog.getSaveFileName(
                 self, title, path, extension_filter, def_filter)
         # Pyside returns tuple, PyQt not
         if isinstance(filenames, tuple):
@@ -383,7 +383,7 @@ class MainWindowUtils(MainWindowBase):
         """
         Show a dialog with the passed widget and OK and cancel buttons.
         """
-        diag = QDialog(self)
+        diag = QtWidgets.QDialog(self)
         diag.setWindowTitle(title)
         diag.setWindowFlags(Qt.Tool)
 
@@ -392,7 +392,7 @@ class MainWindowUtils(MainWindowBase):
         btns.accepted.connect(diag.accept)
         btns.rejected.connect(diag.reject)
 
-        box = QVBoxLayout(diag)
+        box = QtWidgets.QVBoxLayout(diag)
         box.addWidget(widget)
         box.addWidget(btns)
         diag.setLayout(box)

--- a/hyperspyui/mdi_mpl_backend.py
+++ b/hyperspyui/mdi_mpl_backend.py
@@ -22,37 +22,22 @@ Created on Fri Oct 31 14:22:53 2014
 """
 
 import os
+from distutils.version import LooseVersion
 
-import matplotlib.backends.backend_qt4agg
+import matplotlib
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import FigureManagerBase
-from matplotlib import __version__ as mplversionstring
+from matplotlib.backends import backend_qt4agg
 
-mpl13 = mplversionstring.startswith('1.3')
-mpl14 = mplversionstring.startswith('1.4')
-mpl15 = mplversionstring.startswith('1.5')
+from qtpy import QtCore, QtGui, QtWidgets
 
-if mpl13:
-    from matplotlib.backends.qt4_compat import QtCore, QtGui, _getSaveFileName, __version__
-else: # mpl14 or mpl15, or higher
-    from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets, _getSaveFileName, __version__
-
-if mpl13:
-    from matplotlib.backends.backend_qt4 import (QtCore, QtGui, FigureManagerQT, FigureCanvasQT,
-                                                 show, draw_if_interactive, backend_version,
-                                                 NavigationToolbar2QT)
-else: # mpl14 or mpl15, or higher
-    from matplotlib.backends.backend_qt5 import (SPECIAL_KEYS, SUPER, ALT, CTRL,
-                                                 SHIFT, MODIFIER_KEYS, fn_name, cursord,
-                                                 draw_if_interactive, _create_qApp, show, TimerQT,
-                                                 FigureManagerQT,
-                                                 SubplotToolQt, error_msg_qt, exception_handler)
 
 # FigureCanvas definition
-if mpl13:
-    FigureCanvas = matplotlib.backends.backend_qt4agg.FigureCanvasQTAgg
+if LooseVersion(matplotlib.__version__) >= LooseVersion('1.4.0'):
+    FigureCanvas = backend_qt4agg.FigureCanvasQTAgg
 else:  # mpl14 or mpl15, or higher
-    FigureCanvas = matplotlib.backends.backend_qt4agg.FigureCanvas
+    FigureCanvas = backend_qt4agg.FigureCanvas
+
 
 # =================
 # Event managers
@@ -133,7 +118,7 @@ def new_figure_manager(num, *args, **kwargs):
     Create a new figure manager instance. MPL backend function.
     """
     FigureClass = kwargs.pop(
-        'FigureClass', matplotlib.backends.backend_qt4agg.Figure)
+        'FigureClass', matplotlib.figure.Figure)
     thisFig = FigureClass(*args, **kwargs)
     return new_figure_manager_given_figure(num, thisFig)
 
@@ -329,6 +314,7 @@ class FigureManagerMdi(FigureManagerBase):
 
     def set_window_title(self, title):
         self.window.setWindowTitle(title)
+
 
 # Definition for MPL backend:
 FigureManager = FigureManagerMdi

--- a/hyperspyui/mdi_mpl_backend.py
+++ b/hyperspyui/mdi_mpl_backend.py
@@ -35,7 +35,7 @@ mpl15 = mplversionstring.startswith('1.5')
 if mpl13:
     from matplotlib.backends.qt4_compat import QtCore, QtGui, _getSaveFileName, __version__
 else: # mpl14 or mpl15, or higher
-    from matplotlib.backends.qt_compat import QtCore, QtGui, _getSaveFileName, __version__
+    from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets, _getSaveFileName, __version__
 
 if mpl13:
     from matplotlib.backends.backend_qt4 import (QtCore, QtGui, FigureManagerQT, FigureCanvasQT,
@@ -148,7 +148,7 @@ def new_figure_manager_given_figure(num, figure):
     return manager
 
 
-class FigureWindow(QtGui.QMdiSubWindow):
+class FigureWindow(QtWidgets.QMdiSubWindow):
 
     """
     A basic MDI sub-window, but with a closing signal, and an activate QAction,
@@ -156,11 +156,11 @@ class FigureWindow(QtGui.QMdiSubWindow):
     Windows-menu). An exclusive, static action group makes sure only one
     window can be active at the time. If you want to split the windows into
     different groups that can be treated separately, you will need to create
-    your own QActionGroups.
+    your own QtWidgets.QActionGroups.
     """
     closing = QtCore.Signal()
 
-    activeFigureActionGroup = QtGui.QActionGroup(None)
+    activeFigureActionGroup = QtWidgets.QActionGroup(None)
     activeFigureActionGroup.setExclusive(True)
 
     def __init__(self, *args, **kwargs):
@@ -181,7 +181,7 @@ class FigureWindow(QtGui.QMdiSubWindow):
         """
         if self._activate_action is not None:
             return self._activate_action
-        self._activate_action = QtGui.QAction(self.windowTitle(), self)
+        self._activate_action = QtWidgets.QAction(self.windowTitle(), self)
         self._activate_action.setCheckable(True)
         self._activate_action.triggered.connect(self._activate_triggered)
         self.activeFigureActionGroup.addAction(self._activate_action)
@@ -309,7 +309,7 @@ class FigureManagerMdi(FigureManagerBase):
     def destroy(self, *args):
         _on_destroy(self.window)
         # check for qApp first, as PySide deletes it in its atexit handler
-        if QtGui.QApplication.instance() is None:
+        if QtWidgets.QApplication.instance() is None:
             return
         if self.window._destroying:
             return

--- a/hyperspyui/mdi_mpl_backend.py
+++ b/hyperspyui/mdi_mpl_backend.py
@@ -160,7 +160,7 @@ class FigureWindow(QtWidgets.QMdiSubWindow):
     def __init__(self, *args, **kwargs):
         super(FigureWindow, self).__init__(*args, **kwargs)
         self._activate_action = None
-        if os.environ['QT_API'] != 'pyside':
+        if API != 'pyside':
             self.windowStateChanged.connect(self._windowStateChanged)
 
     def closeEvent(self, event):

--- a/hyperspyui/mdi_mpl_backend.py
+++ b/hyperspyui/mdi_mpl_backend.py
@@ -27,15 +27,24 @@ from distutils.version import LooseVersion
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import FigureManagerBase
-from matplotlib.backends import backend_qt4agg
 
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import API, QtCore, QtGui, QtWidgets
 
 
 # FigureCanvas definition
-if LooseVersion(matplotlib.__version__) >= LooseVersion('1.4.0'):
-    FigureCanvas = backend_qt4agg.FigureCanvasQTAgg
-else:  # mpl14 or mpl15, or higher
+if LooseVersion(matplotlib.__version__) >= LooseVersion('2.1.0'):
+    # qt4 and qt5 are the same in matplotlib >= 2.1.0
+    from matplotlib.backends import backend_qt5agg
+    FigureCanvas = backend_qt5agg.FigureCanvasQTAgg
+elif LooseVersion(matplotlib.__version__) >= LooseVersion('2.0.0'):
+    if API == 'pyqt5':
+        from matplotlib.backends import backend_qt5agg
+        FigureCanvas = backend_qt5agg.FigureCanvasQTAgg
+    else:
+        from matplotlib.backends import backend_qt4agg
+        FigureCanvas = backend_qt4agg.FigureCanvasQTAgg
+else:  # < 2.0.0
+    from matplotlib.backends import backend_qt4agg
     FigureCanvas = backend_qt4agg.FigureCanvas
 
 

--- a/hyperspyui/modelwrapper.py
+++ b/hyperspyui/modelwrapper.py
@@ -22,7 +22,7 @@ Created on Tue Nov 04 16:25:54 2014
 """
 
 
-from python_qt_binding import QtCore, QtGui
+from qtpy import QtCore, QtGui
 #from hyperspy.model import Model
 import hyperspy.models.eelsmodel
 from .actionable import Actionable

--- a/hyperspyui/modelwrapper.py
+++ b/hyperspyui/modelwrapper.py
@@ -22,7 +22,7 @@ Created on Tue Nov 04 16:25:54 2014
 """
 
 
-from qtpy import QtCore, QtGui
+from qtpy import QtCore
 #from hyperspy.model import Model
 import hyperspy.models.eelsmodel
 from .actionable import Actionable

--- a/hyperspyui/overrides.py
+++ b/hyperspyui/overrides.py
@@ -22,7 +22,7 @@ Created on Fri Dec 19 03:43:51 2014
 """
 
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 import hyperspy.drawing.utils
 
 orig_on_figure_window_close = hyperspy.drawing.utils.on_figure_window_close

--- a/hyperspyui/overrides.py
+++ b/hyperspyui/overrides.py
@@ -44,9 +44,7 @@ def _on_figure_window_close(figure, function):
     if function not in figure._on_window_close:
         figure._on_window_close.append(function)
 
-    # PyQt
-    # In PyQt window.connect supports multiple funtions
-    window.connect(window, QtCore.SIGNAL('closing()'), function)
+    window.closing.connect(function)
 
 
 def override_hyperspy():

--- a/hyperspyui/overrides.py
+++ b/hyperspyui/overrides.py
@@ -22,12 +22,6 @@ Created on Fri Dec 19 03:43:51 2014
 """
 
 
-from qtpy import QtCore
-import hyperspy.drawing.utils
-
-orig_on_figure_window_close = hyperspy.drawing.utils.on_figure_window_close
-
-
 def _on_figure_window_close(figure, function):
     """Connects a close figure signal to a given function.
 
@@ -48,4 +42,9 @@ def _on_figure_window_close(figure, function):
 
 
 def override_hyperspy():
+    import hyperspy.drawing.utils
     hyperspy.drawing.utils.on_figure_window_close = _on_figure_window_close
+    
+    from hyperspy.defaults_parser import preferences
+    preferences.GUIs.enable_ipywidgets_gui = False
+    preferences.GUIs.enable_traitsui_gui = True

--- a/hyperspyui/pluginmanager.py
+++ b/hyperspyui/pluginmanager.py
@@ -27,7 +27,6 @@ import glob
 import importlib
 import warnings
 import traceback
-import logging
 
 from hyperspyui.log import logger
 from hyperspyui.plugins.plugin import Plugin

--- a/hyperspyui/plugins/align.py
+++ b/hyperspyui/plugins/align.py
@@ -18,9 +18,9 @@
 
 from hyperspyui.plugins.plugin import Plugin
 import numpy as np
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QDialogButtonBox
+
 
 from hyperspyui.tools import SelectionTool
 from hyperspyui.util import SignalTypeFilter
@@ -336,9 +336,9 @@ class ManualAlignDialog(ExToolWindow):
 
     def create_controls(self):
         self.setWindowTitle("Align signal")
-        form = QFormLayout()
-        self.num_x = QSpinBox()
-        self.num_y = QSpinBox()
+        form = QtWidgets.QFormLayout()
+        self.num_x = QtWidgets.QSpinBox()
+        self.num_y = QtWidgets.QSpinBox()
         self.num_x.valueChanged.connect(self.update_x)
         self.num_y.valueChanged.connect(self.update_y)
         dims = self.signal.axes_manager.signal_shape
@@ -348,10 +348,10 @@ class ManualAlignDialog(ExToolWindow):
         self.num_y.setMinimum(-dims[1])
         form.addRow("X:", self.num_x)
         form.addRow("Y:", self.num_y)
-        vbox = QVBoxLayout()
+        vbox = QtWidgets.QVBoxLayout()
         vbox.addLayout(form)
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
-                                Qt.Horizontal, self)
+                                QtCore.Qt.Horizontal, self)
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         vbox.addWidget(btns)

--- a/hyperspyui/plugins/align.py
+++ b/hyperspyui/plugins/align.py
@@ -18,9 +18,9 @@
 
 from hyperspyui.plugins.plugin import Plugin
 import numpy as np
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.tools import SelectionTool
 from hyperspyui.util import SignalTypeFilter

--- a/hyperspyui/plugins/alignzlp.py
+++ b/hyperspyui/plugins/alignzlp.py
@@ -1,6 +1,4 @@
 from hyperspyui.plugins.plugin import Plugin
-import numpy as np
-import hyperspy.api as hs
 
 
 class Alignzlp(Plugin):

--- a/hyperspyui/plugins/alignzlp.py
+++ b/hyperspyui/plugins/alignzlp.py
@@ -23,6 +23,5 @@ class Alignzlp(Plugin):
 
     def default(self):
         ui = self.ui
-        siglist = ui.hspy_signals
         s = ui.get_selected_signal()
         s.align_zero_loss_peak()

--- a/hyperspyui/plugins/axesconf.py
+++ b/hyperspyui/plugins/axesconf.py
@@ -63,4 +63,4 @@ class AxesConf(Plugin):
         Creates the taitsui dialog. The TraitsWidget captures and displays it.
         """
         sig = win2sig(window)
-        sig.signal.axes_manager.show()
+        sig.signal.axes_manager.gui()

--- a/hyperspyui/plugins/axesorderwidget.py
+++ b/hyperspyui/plugins/axesorderwidget.py
@@ -23,7 +23,7 @@ Created on Tue Apr 28 11:00:55 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
+from qtpy import QtGui, QtCore, QtWidgets
 import collections
 
 from hyperspyui.util import win2sig
@@ -111,7 +111,7 @@ class AxesOrderWidget(FigureWidget):
         for ax in signal.signal.axes_manager._get_axes_in_natural_order():
             rep = '%s axis, size: %i' % (ax._get_name(), ax.size)
             p = self.lst_nav if ax.navigate else self.lst_sig
-            i = QtGui.QListWidgetItem(rep)
+            i = QtWidgets.QListWidgetItem(rep)
             i.setData(QtCore.Qt.UserRole, ax)
             p.addItem(i)
 
@@ -207,10 +207,10 @@ class AxesOrderWidget(FigureWidget):
         self.lst_sig = AxesListWidget(self)
 
         sp = self.lst_sig.sizePolicy()
-        sp.setVerticalPolicy(QtGui.QSizePolicy.Fixed)
+        sp.setVerticalPolicy(QtWidgets.QSizePolicy.Fixed)
         self.lst_sig.setSizePolicy(sp)
         sp = self.lst_nav.sizePolicy()
-        sp.setVerticalPolicy(QtGui.QSizePolicy.Fixed)
+        sp.setVerticalPolicy(QtWidgets.QSizePolicy.Fixed)
         self.lst_nav.setSizePolicy(sp)
 
         self.btn_down.clicked.connect(self._move_down)
@@ -239,9 +239,9 @@ class AxesOrderWidget(FigureWidget):
         self.setWidget(w)
 
 
-class AxesListWidget(QtGui.QListWidget):
-    inserted = QtCore.Signal(int, int, QtGui.QListWidget)
-    moved = QtCore.Signal(QtGui.QListWidgetItem, int, QtGui.QListWidget)
+class AxesListWidget(QtWidgets.QListWidget):
+    inserted = QtCore.Signal(int, int, QtWidgets.QListWidget)
+    moved = QtCore.Signal(QtWidgets.QListWidgetItem, int, QtWidgets.QListWidget)
 
     last_drop = None
 

--- a/hyperspyui/plugins/axesorderwidget.py
+++ b/hyperspyui/plugins/axesorderwidget.py
@@ -23,7 +23,10 @@ Created on Tue Apr 28 11:00:55 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import (QLabel, QPushButton, QToolButton, QVBoxLayout,
+                            QHBoxLayout, QWidget)
+
 import collections
 
 from hyperspyui.util import win2sig
@@ -197,13 +200,13 @@ class AxesOrderWidget(FigureWidget):
         self.plugin.flip_axes(axes)
 
     def create_controls(self):
-        self.lbl_nav = QtGui.QLabel(tr("Navigate"), self)
+        self.lbl_nav = QLabel(tr("Navigate"), self)
         self.lst_nav = AxesListWidget(self)
-        self.btn_up = QtGui.QToolButton(self)
+        self.btn_up = QToolButton(self)
         self.btn_up.setArrowType(QtCore.Qt.UpArrow)
-        self.btn_down = QtGui.QToolButton(self)
+        self.btn_down = QToolButton(self)
         self.btn_down.setArrowType(QtCore.Qt.DownArrow)
-        self.lbl_sig = QtGui.QLabel(tr("Signal"), self)
+        self.lbl_sig = QLabel(tr("Signal"), self)
         self.lst_sig = AxesListWidget(self)
 
         sp = self.lst_sig.sizePolicy()
@@ -220,13 +223,13 @@ class AxesOrderWidget(FigureWidget):
         self.lst_nav.moved.connect(self._list_move)
         self.lst_sig.moved.connect(self._list_move)
 
-        self.btn_flip = QtGui.QPushButton(tr("Reverse axes"))
+        self.btn_flip = QPushButton(tr("Reverse axes"))
         self.btn_flip.clicked.connect(self._flip_clicked)
 
-        vbox = QtGui.QVBoxLayout()
+        vbox = QVBoxLayout()
         vbox.addWidget(self.lbl_nav)
         vbox.addWidget(self.lst_nav)
-        hbox = QtGui.QHBoxLayout()
+        hbox = QHBoxLayout()
         hbox.addWidget(self.btn_up)
         hbox.addWidget(self.btn_down)
         vbox.addLayout(hbox)
@@ -234,7 +237,7 @@ class AxesOrderWidget(FigureWidget):
         vbox.addWidget(self.lst_sig)
         vbox.addWidget(self.btn_flip)
 
-        w = QtGui.QWidget()
+        w = QWidget()
         w.setLayout(vbox)
         self.setWidget(w)
 
@@ -248,8 +251,8 @@ class AxesListWidget(QtWidgets.QListWidget):
     def __init__(self, type, parent=None):
         super(AxesListWidget, self).__init__(parent)
         self.setIconSize(QtCore.QSize(124, 124))
-        self.setDragDropMode(QtGui.QAbstractItemView.DragDrop)
-        self.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
+        self.setDragDropMode(QtWidgets.QAbstractItemView.DragDrop)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setAcceptDrops(True)
         m = self.model()
         m.rowsInserted.connect(self._on_rows_inserted)

--- a/hyperspyui/plugins/axesorderwidget.py
+++ b/hyperspyui/plugins/axesorderwidget.py
@@ -23,7 +23,7 @@ Created on Tue Apr 28 11:00:55 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
+from qtpy import QtGui, QtCore
 import collections
 
 from hyperspyui.util import win2sig

--- a/hyperspyui/plugins/basicsignal.py
+++ b/hyperspyui/plugins/basicsignal.py
@@ -26,9 +26,9 @@ import sys
 from hyperspyui.plugins.plugin import Plugin
 from hyperspy.utils import stack as stack_signals
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.widgets.axespicker import AxesPickerDialog
 

--- a/hyperspyui/plugins/basicsignal.py
+++ b/hyperspyui/plugins/basicsignal.py
@@ -26,15 +26,13 @@ import sys
 from hyperspyui.plugins.plugin import Plugin
 from hyperspy.utils import stack as stack_signals
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
 
 from hyperspyui.widgets.axespicker import AxesPickerDialog
 
 
 def tr(text):
-    return QCoreApplication.translate("BasicSignalPlugin", text)
+    return QtCore.QCoreApplication.translate("BasicSignalPlugin", text)
 
 
 class BasicSignalPlugin(Plugin):
@@ -252,7 +250,7 @@ class BasicSignalPlugin(Plugin):
         diag = AxesPickerDialog(self.ui, signal, single)
         diag.setWindowTitle("Select axes to operate on")
         dr = diag.exec_()
-        if dr == QtGui.QDialog.Accepted:
+        if dr == QtWidgets.QDialog.Accepted:
             return diag.selected_axes
         return None
 

--- a/hyperspyui/plugins/basicspectrum.py
+++ b/hyperspyui/plugins/basicspectrum.py
@@ -23,12 +23,9 @@ Created on Sun Mar 01 15:20:55 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
 
 from hyperspyui.widgets.elementpicker import ElementPickerWidget
-from hyperspyui.threaded import Threaded
 from hyperspyui.util import SignalTypeFilter
 from hyperspyui.tools import SignalFigureTool
 
@@ -41,7 +38,7 @@ from functools import partial
 
 
 def tr(text):
-    return QCoreApplication.translate("BasicSpectrumPlugin", text)
+    return QtCore.QCoreApplication.translate("BasicSpectrumPlugin", text)
 
 
 class Namespace:
@@ -311,7 +308,7 @@ class BasicSpectrumPlugin(Plugin):
 
 
 class ElementPickerTool(SignalFigureTool):
-    picked = Signal(str)
+    picked = QtCore.Signal(str)
 
     def __init__(self, windows=None):
         super(ElementPickerTool, self).__init__(windows)
@@ -347,7 +344,7 @@ class ElementPickerTool(SignalFigureTool):
         from hyperspy.misc.eds.utils import get_xray_lines_near_energy
         lines = get_xray_lines_near_energy(energy)
         if lines:
-            m = QMenu()
+            m = QtWidgets.QMenu()
             for line in lines:
                 m.addAction(line, partial(self.on_pick_line, line))
             m.exec_(QCursor.pos())

--- a/hyperspyui/plugins/basicspectrum.py
+++ b/hyperspyui/plugins/basicspectrum.py
@@ -23,9 +23,9 @@ Created on Sun Mar 01 15:20:55 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.widgets.elementpicker import ElementPickerWidget
 from hyperspyui.threaded import Threaded

--- a/hyperspyui/plugins/cmappicker.py
+++ b/hyperspyui/plugins/cmappicker.py
@@ -29,12 +29,11 @@ from hyperspyui.widgets.extendedqwidgets import FigureWidget
 from hyperspyui.util import win2fig, fig2image_plot
 
 from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy.QtCore import Qt
 
 
 def tr(text):
-    return QCoreApplication.translate("ColorMapPickerPlugi", text)
+    return QtCore.QCoreApplication.translate("ColorMapPickerPlugi", text)
 
 
 class CMapPickerPlugin(Plugin):
@@ -72,7 +71,7 @@ cmaps = [('Uniform',        ['viridis', 'inferno', 'plasma', 'magma']),
                              'gist_rainbow', 'hsv', 'flag', 'prism'])]
 
 
-class CMapDelegate(QItemDelegate):
+class CMapDelegate(QtWidgets.QItemDelegate):
     """
     Delegate responsible for drawing a the entries in the colormap combobox.
 
@@ -92,20 +91,20 @@ class CMapDelegate(QItemDelegate):
         width = line.shape[0]
         data = line[:, [2, 1, 0, 3]]
         data = np.tile(data, (height, 1, 1))
-        im = QImage(data.data, width, height, QImage.Format_ARGB32)
+        im = QtGui.QImage(data.data, width, height, QtGui.QImage.Format_ARGB32)
         im.ndarray = data
-        return QPixmap.fromImage(im)
+        return QtGui.QPixmap.fromImage(im)
 
     def paint(self, painter, option, index):
 
         kind = index.data(Qt.AccessibleDescriptionRole)
         if kind == "parent":
-            option.state |= QStyle.State_Enabled
+            option.state |= QtWidgets.QStyle.State_Enabled
         else:
             option.textElideMode = Qt.ElideNone
             rect = option.rect
-            rect = QRect(rect.x()+self.cmap_shift, rect.y(),
-                         rect.width()-self.cmap_shift, rect.height())
+            rect = QtWidgets.QRect(rect.x()+self.cmap_shift, rect.y(),
+                                   rect.width()-self.cmap_shift, rect.height())
             option.rect.setLeft(option.rect.x() + 10)
         super(CMapDelegate, self).paint(painter, option, index)
 
@@ -118,7 +117,7 @@ class CMapDelegate(QItemDelegate):
             painter.drawPixmap(rect, pixmap)
 
     def sizeHint(self, option, index):
-        return QSize(self.width_, self.height_)
+        return QtCore.QSize(self.width_, self.height_)
 
     def drawFocus(self, painter, option, rect):
         super(CMapDelegate, self).drawFocus(painter, option, rect)
@@ -171,7 +170,7 @@ class CMapPickerWidget(FigureWidget):
 
     @staticmethod
     def make_parent_item(text):
-        item = QStandardItem(text)
+        item = QtGui.QStandardItem(text)
         item.setFlags(item.flags() & ~(Qt.ItemIsEnabled | Qt.ItemIsSelectable))
         item.setData("parent", Qt.AccessibleDescriptionRole)
 
@@ -182,7 +181,7 @@ class CMapPickerWidget(FigureWidget):
         return item
 
     def create_controls(self):
-        self.cbo = QComboBox()
+        self.cbo = QtWidgets.QComboBox()
         self.cbo.setItemDelegate(CMapDelegate(256, 18, 80, self.cbo))
         for group, maps in cmaps:
             self.cbo.model().appendRow(self.make_parent_item(group))
@@ -190,10 +189,10 @@ class CMapPickerWidget(FigureWidget):
                 self.cbo.addItem(cm)
         self.cbo.currentIndexChanged[str].connect(
             self._on_select)
-        vbox = QVBoxLayout()
+        vbox = QtWidgets.QVBoxLayout()
         vbox.addWidget(self.cbo)
 
-        wrap = QWidget()
+        wrap = QtWidgets.QWidget()
         wrap.setLayout(vbox)
         height = vbox.sizeHint().height()
         wrap.setFixedHeight(height)

--- a/hyperspyui/plugins/cmappicker.py
+++ b/hyperspyui/plugins/cmappicker.py
@@ -28,9 +28,9 @@ from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.extendedqwidgets import FigureWidget
 from hyperspyui.util import win2fig, fig2image_plot
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 
 def tr(text):
@@ -142,7 +142,7 @@ class CMapPickerWidget(FigureWidget):
 
     def _on_figure_change(self, figure):
         super(CMapPickerWidget, self)._on_figure_change(figure)
-        if isinstance(figure, QMdiSubWindow):
+        if isinstance(figure, QtWidgets.QMdiSubWindow):
             figure = win2fig(figure)
 
         signals = self.parent().signals

--- a/hyperspyui/plugins/eelsdb.py
+++ b/hyperspyui/plugins/eelsdb.py
@@ -23,9 +23,9 @@ Created on Mon May 04 17:30:36 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore, QtWebKit, QtNetwork
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWebKit, QtNetwork
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 from QtWebKit import *
 from QtNetwork import *
 

--- a/hyperspyui/plugins/eelsdb.py
+++ b/hyperspyui/plugins/eelsdb.py
@@ -23,14 +23,11 @@ Created on Mon May 04 17:30:36 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore, QtWebKit, QtNetwork
-from qtpy.QtCore import *
-from qtpy.QtGui import *
-from QtWebKit import *
-from QtNetwork import *
+from qtpy import QtCore, QtNetwork, QtWidgets, QtWebEngineWidgets
+    
 
 try:
-    assert(QSslSocket.supportsSsl())
+    assert(QtNetwork.QSslSocket.supportsSsl())
 except NameError as AssertionError:
     raise ImportError("Current platform doesn't support SSL. EELSDB plugin"
                       " disabled.")
@@ -62,12 +59,12 @@ class EELSDBPlugin(Plugin):
         self.add_menuitem('EELS', self.ui.actions[self.name + '.browse'])
 
     def _make_request(self, url):
-        request = QNetworkRequest()
-        request.setUrl(QUrl(url))
+        request = QtNetwork.QNetworkRequest()
+        request.setUrl(QtCore.QUrl(url))
         return request
 
     def load_blocking(self, view, *args):
-        loop = QEventLoop()
+        loop = QtCore.QEventLoop()
         view.loadFinished.connect(loop.quit)
 
         def unravel():
@@ -79,10 +76,10 @@ class EELSDBPlugin(Plugin):
         loop.exec_()
 
     def _on_link(self, url):
-        su = url.toString(QUrl.RemoveQuery)
+        su = url.toString(QtCore.QUrl.RemoveQuery)
         if "/spectra/" in su:
-            view = QWebView(self.ui)
-            wp = QWebPage()
+            view = QtWebEngineWidgets.QWebEngineView(self.ui)
+            wp = QtWebEngineWidgets.QWebEnginePage()
             am = self.view.page().networkAccessManager()
             wp.setNetworkAccessManager(am)
             view.setPage(wp)
@@ -128,20 +125,21 @@ class EELSDBPlugin(Plugin):
         if self.window is None:
             self.window = ExToolWindow(self.ui)
             self.window.setWindowTitle("EELSDB")
-            vbox = QVBoxLayout()
+            vbox = QtWidgets.QVBoxLayout()
             self.window.setLayout(vbox)
-            view = QWebView(self.ui)
+            view = QtWebEngineWidgets.QWebEngineView(self.ui)
             self.view = view
             vbox.addWidget(view)
             self.window.resize(self.view.sizeHint())
         # Load spectra browser
-        browse_url = QUrl("https://eelsdb.eu/spectra")
+        browse_url = QtCore.QUrl("https://eelsdb.eu/spectra")
         self.load_blocking(self.view, browse_url)
         # Remove header/footer
         frame = self.view.page().mainFrame()
         frame.findFirstElement(".footer").removeFromDocument()
         for el in frame.findAllElements(".navbar"):
             el.removeFromDocument()
-        self.view.page().setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
+        self.view.page().setLinkDelegationPolicy(
+                QtWebEngineWidgets.QWebEnginePage.DelegateAllLinks)
         self.view.linkClicked.connect(self._on_link)
         self.window.show()

--- a/hyperspyui/plugins/fft.py
+++ b/hyperspyui/plugins/fft.py
@@ -33,13 +33,11 @@ import hyperspy.signals
 
 from hyperspyui.threaded import ProgressThreaded
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore
 
 
 def tr(text):
-    return QCoreApplication.translate("FFT", text)
+    return QtCore.QCoreApplication.translate("FFT", text)
 
 
 class FFT_Plugin(Plugin):

--- a/hyperspyui/plugins/fft.py
+++ b/hyperspyui/plugins/fft.py
@@ -33,9 +33,9 @@ import hyperspy.signals
 
 from hyperspyui.threaded import ProgressThreaded
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 
 def tr(text):

--- a/hyperspyui/plugins/gaussianfilter.py
+++ b/hyperspyui/plugins/gaussianfilter.py
@@ -22,7 +22,7 @@ from skimage.filters import gaussian
 from hyperspyui.util import win2sig
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 
-from python_qt_binding import QtGui, QtCore
+from qtpy import QtGui, QtCore
 
 
 def tr(text):

--- a/hyperspyui/plugins/gitgetter.py
+++ b/hyperspyui/plugins/gitgetter.py
@@ -18,11 +18,12 @@
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
-
-from hyperspyui.widgets.extendedqwidgets import ExToolWindow
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QDialogButtonBox
+from qtpy.QtWidgets import (QCheckBox, QPushButton, QHBoxLayout, QVBoxLayout, 
+                            QFormLayout, QDialog, QMessageBox, QLabel, QWidget,
+                            QComboBox, QTextEdit)
+from qtpy.QtCore import Qt
 
 import os
 import re
@@ -79,7 +80,7 @@ try:
         except git.cmd.GitCommandNotFound:
             if prompt:
                 ext_filt = '*.exe' if os.name == 'NT' else None
-                path = QFileDialog.getOpenFileName(
+                path = QtWidgets.QFileDialog.getOpenFileName(
                     parent, tr('Specify git executable'),
                     git.Git.GIT_PYTHON_GIT_EXECUTABLE, ext_filt)
                 # Pyside returns tuple, PyQt not
@@ -292,7 +293,7 @@ class GitSelector(Plugin):
             diag = self.ui.show_okcancel_dialog("Updates available", w)
             if diag.result() == QDialog.Accepted:
                 for chk in w.children():
-                    if isinstance(chk, QCheckBox):
+                    if isinstance(chk, QtWidgets.QCheckBox):
                         name = chk.text()
                         if available[name]:
                             name += '==' + available[name]
@@ -413,7 +414,7 @@ class VisualLogStream(StringIO):
             StringIO.write(self, s)
             self._ensure_dialog()
             self.dialog.output.setPlainText(self.getvalue())
-            QApplication.processEvents()
+            QtWidgets.QApplication.processEvents()
 
 
 class PipOutput(QDialog):

--- a/hyperspyui/plugins/gitgetter.py
+++ b/hyperspyui/plugins/gitgetter.py
@@ -18,9 +18,9 @@
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 

--- a/hyperspyui/plugins/imagerotation.py
+++ b/hyperspyui/plugins/imagerotation.py
@@ -22,9 +22,10 @@ Created on Wed Jan 21 14:49:08 2015
 """
 
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore
+from qtpy.QtWidgets import (QCheckBox, QPushButton, QHBoxLayout, QVBoxLayout, 
+                            QFormLayout, QDoubleSpinBox, QGroupBox, QSpinBox,
+                            QRadioButton)
 
 from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
@@ -35,7 +36,7 @@ from hyperspyui.signalwrapper import SignalWrapper
 
 
 def tr(text):
-    return QCoreApplication.translate("ImageRotation", text)
+    return QtCore.QCoreApplication.translate("ImageRotation", text)
 
 
 class ImageRotation_Plugin(Plugin):

--- a/hyperspyui/plugins/imagerotation.py
+++ b/hyperspyui/plugins/imagerotation.py
@@ -22,9 +22,9 @@ Created on Wed Jan 21 14:49:08 2015
 """
 
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow

--- a/hyperspyui/plugins/metadataeditor.py
+++ b/hyperspyui/plugins/metadataeditor.py
@@ -19,9 +19,9 @@
 from functools import partial
 from collections import OrderedDict
 
-from python_qt_binding import QtGui, QtCore, QtSvg
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtSvg
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow

--- a/hyperspyui/plugins/metadataeditor.py
+++ b/hyperspyui/plugins/metadataeditor.py
@@ -19,9 +19,9 @@
 from functools import partial
 from collections import OrderedDict
 
-from qtpy import QtGui, QtCore, QtSvg
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QDialogButtonBox
+from qtpy.QtCore import Qt, QModelIndex
 
 from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
@@ -29,7 +29,7 @@ from hyperspy.misc.utils import DictionaryTreeBrowser
 
 
 def tr(text):
-    return QCoreApplication.translate("MetadataEditor", text)
+    return QtCore.QCoreApplication.translate("MetadataEditor", text)
 
 
 class MetadataEditor(Plugin):
@@ -61,7 +61,7 @@ class MetadataEditor(Plugin):
             diag = ExToolWindow(parent=self.ui)
             sw = self.ui.lut_signalwrapper[signal]
             diag.setWindowTitle(tr("Metadata of %s") % sw.name)
-            vbox = QVBoxLayout()
+            vbox = QtWidgets.QVBoxLayout()
             tw = MetadataTreeWidget(signal)
             vbox.addWidget(tw)
             btns = QDialogButtonBox(QDialogButtonBox.Ok)
@@ -73,7 +73,7 @@ class MetadataEditor(Plugin):
             self.editors[signal] = diag
 
 
-class MetadataTreeWidget(QTreeView):
+class MetadataTreeWidget(QtWidgets.QTreeView):
 
     def __init__(self, signal, parent=None):
         super(MetadataTreeWidget, self).__init__(parent)
@@ -144,7 +144,7 @@ class MetadataNode:
         return False
 
 
-class MetadataModel(QAbstractItemModel):
+class MetadataModel(QtCore.QAbstractItemModel):
 
     def __init__(self, signal, parent=None):
         super(MetadataModel, self).__init__(parent=parent)

--- a/hyperspyui/plugins/mirrorplot.py
+++ b/hyperspyui/plugins/mirrorplot.py
@@ -23,9 +23,9 @@ Created on Sun Mar 01 15:18:30 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 import hyperspy.utils.plot
 

--- a/hyperspyui/plugins/mirrorplot.py
+++ b/hyperspyui/plugins/mirrorplot.py
@@ -23,15 +23,14 @@ Created on Sun Mar 01 15:18:30 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore
+from qtpy.QtWidgets import QMessageBox
 
 import hyperspy.utils.plot
 
 
 def tr(text):
-    return QCoreApplication.translate("MirrorPlotPlugin", text)
+    return QtCore.QCoreApplication.translate("MirrorPlotPlugin", text)
 
 
 class MirrorPlotPlugin(Plugin):

--- a/hyperspyui/plugins/moviesaver.py
+++ b/hyperspyui/plugins/moviesaver.py
@@ -22,13 +22,12 @@ import matplotlib.animation as animation
 import os
 import sys
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QLineEdit, QCheckBox
 
 
 def tr(text):
-    return QCoreApplication.translate("MovieSaver", text)
+    return QtCore.QCoreApplication.translate("MovieSaver", text)
 
 
 # =============================================================================
@@ -80,7 +79,7 @@ class MovieSaver(Plugin):
         fname += os.path.extsep + "mp4"
         dlg.edt_fname.setText(fname)
         dlg_w = self.ui.show_okcancel_dialog(tr("Save movie"), dlg)
-        if dlg_w.result() == QDialog.Accepted:
+        if dlg_w.result() == QtWidgets.QDialog.Accepted:
             # Setup writer:
             fps = dlg.num_fps.value()
             codec = dlg.edt_codec.text()
@@ -130,7 +129,7 @@ class MovieSaver(Plugin):
             try:
                 with writer.saving(fig, fname, dpi):
                     for idx in signal.axes_manager:
-                        QApplication.processEvents()
+                        QtWidgets.QApplication.processEvents()
                         writer.grab_frame()
             finally:
                 # Reset figure props:
@@ -143,21 +142,21 @@ class MovieSaver(Plugin):
                 fig.canvas.draw()
 
 
-class MovieArgsPrompt(QWidget):
+class MovieArgsPrompt(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         super(MovieArgsPrompt, self).__init__(parent)
         self.create_controls()
 
     def create_controls(self):
-        self.num_fps = QDoubleSpinBox()
+        self.num_fps = QtWidgets.QDoubleSpinBox()
         self.num_fps.setValue(15.0)
         self.num_fps.setMinimum(0.001)
 
         self.edt_fname = QLineEdit()
-        self.btn_browse = QPushButton("...")
+        self.btn_browse = QtWidgets.QPushButton("...")
 
-        self.num_dpi = QSpinBox()
+        self.num_dpi = QtWidgets.QSpinBox()
         self.num_dpi.setValue(72)
         self.num_dpi.setMinimum(1)
         self.num_dpi.setMaximum(10000)
@@ -182,13 +181,13 @@ class MovieArgsPrompt(QWidget):
             self.chk_verbose.setToolTip("Verbose output does not work with " +
                                         "internal console.")
 
-        frm = QFormLayout()
+        frm = QtWidgets.QFormLayout()
         frm.addRow(tr("FPS:"), self.num_fps)
         frm.addRow(tr("DPI:"), self.num_dpi)
         frm.addRow(tr("Codec:"), self.edt_codec)
         frm.addRow(tr("Extra args:"), self.edt_extra)
         frm.addRow(self.chk_axes, self.chk_colorbar)
-        hbox = QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(self.edt_fname)
         hbox.addWidget(self.btn_browse)
         frm.addRow(tr("File:"), hbox)

--- a/hyperspyui/plugins/moviesaver.py
+++ b/hyperspyui/plugins/moviesaver.py
@@ -22,9 +22,9 @@ import matplotlib.animation as animation
 import os
 import sys
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 
 def tr(text):

--- a/hyperspyui/plugins/mva.py
+++ b/hyperspyui/plugins/mva.py
@@ -24,9 +24,8 @@ Created on Fri Dec 12 23:44:01 2014
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QDialog, QDialogButtonBox, QLineEdit, QLabel
 
 from hyperspy.learn.mva import LearningResults
 from hyperspyui.util import win2sig, fig2win, Namespace
@@ -35,7 +34,7 @@ from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 
 
 def tr(text):
-    return QCoreApplication.translate("MVA", text)
+    return QtCore.QCoreApplication.translate("MVA", text)
 
 
 def align_yaxis(ax1, v1, ax2, v2):
@@ -57,10 +56,10 @@ def make_advanced_dialog(ui, algorithms=None):
 
     diag.setWindowTitle("Decomposition parameters")
 
-    vbox = QVBoxLayout()
+    vbox = QtWidgets.QVBoxLayout()
     if algorithms:
         lbl_algo = QLabel(tr("Choose algorithm:"))
-        cbo_algo = QComboBox()
+        cbo_algo = QLineEdit.QComboBox()
         cbo_algo.addItems(algorithms)
 
         vbox.addWidget(lbl_algo)
@@ -74,7 +73,7 @@ def make_advanced_dialog(ui, algorithms=None):
         vbox.addWidget(txt_comp)
 
     btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
-                            Qt.Horizontal)
+                            QtCore.Qt.Horizontal)
     btns.accepted.connect(diag.accept)
     btns.rejected.connect(diag.reject)
     vbox.addWidget(btns)
@@ -226,7 +225,7 @@ class MVA_Plugin(Plugin):
             ns.s = self._do_decomposition(ns.s, algorithm=algorithm)
 
         def on_error(message=None):
-            em = QErrorMessage(self.ui)
+            em = QtWidgets.QErrorMessage(self.ui)
             msg = tr("An error occurred during decomposition")
             if message:
                 msg += ":\n" + message

--- a/hyperspyui/plugins/mva.py
+++ b/hyperspyui/plugins/mva.py
@@ -24,9 +24,9 @@ Created on Fri Dec 12 23:44:01 2014
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspy.learn.mva import LearningResults
 from hyperspyui.util import win2sig, fig2win, Namespace

--- a/hyperspyui/plugins/rebin.py
+++ b/hyperspyui/plugins/rebin.py
@@ -23,15 +23,13 @@ Created on Wed Jan 07 23:37:51 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
 
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 
 
 def tr(text):
-    return QCoreApplication.translate("Rebin", text)
+    return QtCore.QCoreApplication.translate("Rebin", text)
 
 
 class RebinPlugin(Plugin):
@@ -104,7 +102,7 @@ class RebinDialog(ExToolWindow):
         self.plugin.rebin(factors, self.signal)
 
     def validate(self):
-        style = QApplication.style()
+        style = QtWidgets.QApplication.style()
         tmpIcon = style.standardIcon(style.SP_MessageBoxWarning, None, self)
         s = self.signal
         for ax in s.signal.axes_manager._get_axes_in_natural_order():
@@ -116,12 +114,12 @@ class RebinDialog(ExToolWindow):
                     # No warning icon yet
                     iconSize = spin.height()
                     pm = tmpIcon.pixmap(iconSize, iconSize)
-                    lbl = QLabel()
+                    lbl = QtWidgets.QLabel()
                     lbl.setPixmap(pm)
                     lbl.setToolTip(tr("Not a factor of shape. Input data " +
                                       "will be trimmed before binning."))
                     sp = lbl.sizePolicy()
-                    sp.setHorizontalPolicy(QSizePolicy.Maximum)
+                    sp.setHorizontalPolicy(QtWidgets.QSizePolicy.Maximum)
                     lbl.setSizePolicy(sp)
                     hbox.insertWidget(0, lbl)
             else:
@@ -133,22 +131,22 @@ class RebinDialog(ExToolWindow):
     def create_controls(self):
         self.spins = {}
         self.hboxes = {}
-        form = QFormLayout()
+        form = QtWidgets.QFormLayout()
         for ax in self.signal.signal.axes_manager._get_axes_in_natural_order():
-            spin = QSpinBox(self)
+            spin = QtWidgets.QSpinBox(self)
             spin.setValue(1)
             spin.setMinimum(1)
             spin.valueChanged.connect(self.validate)
             self.spins[ax.name] = spin
-            hbox = QHBoxLayout()
+            hbox = QtWidgets.QHBoxLayout()
             hbox.addWidget(spin)
             form.addRow(ax.name, hbox)
             self.hboxes[ax.name] = hbox
         self.form = form
-        self.btn_rebin = QPushButton(tr("Rebin"))
+        self.btn_rebin = QtWidgets.QPushButton(tr("Rebin"))
         self.btn_rebin.clicked.connect(self.rebin)
 
-        vbox = QVBoxLayout()
+        vbox = QtWidgets.QVBoxLayout()
         vbox.addLayout(form)
         vbox.addWidget(self.btn_rebin)
 

--- a/hyperspyui/plugins/rebin.py
+++ b/hyperspyui/plugins/rebin.py
@@ -23,9 +23,9 @@ Created on Wed Jan 07 23:37:51 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 

--- a/hyperspyui/plugins/recorderwidget.py
+++ b/hyperspyui/plugins/recorderwidget.py
@@ -23,9 +23,9 @@ Created on Sun Feb 22 18:46:40 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.recorder import Recorder
 from hyperspyui.widgets.editorwidget import EditorWidget

--- a/hyperspyui/plugins/recorderwidget.py
+++ b/hyperspyui/plugins/recorderwidget.py
@@ -23,19 +23,19 @@ Created on Sun Feb 22 18:46:40 2015
 
 from hyperspyui.plugins.plugin import Plugin
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import (QPushButton, QVBoxLayout, QWidget, QHBoxLayout,
+                            QCheckBox)
 
 from hyperspyui.recorder import Recorder
 from hyperspyui.widgets.editorwidget import EditorWidget
 
 
 def tr(text):
-    return QCoreApplication.translate("RecorderWidget", text)
+    return QtCore.QCoreApplication.translate("RecorderWidget", text)
 
 
-class RecorderWidget(QDockWidget):
+class RecorderWidget(QtWidgets.QDockWidget):
 
     def __init__(self, main_window, parent=None):
         super(RecorderWidget, self).__init__(parent)

--- a/hyperspyui/plugins/stylesheet.py
+++ b/hyperspyui/plugins/stylesheet.py
@@ -22,8 +22,11 @@ from functools import partial
 from collections import OrderedDict
 
 from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy.QtWidgets import (QApplication, QPushButton, QLabel, QGroupBox,
+                            QHBoxLayout, QVBoxLayout, QComboBox)
+
+from qtpy.QtGui import QPalette
+
 
 from pyqode.core import api
 from pyqode.core import modes
@@ -36,7 +39,7 @@ from hyperspyui.util import block_signals
 
 
 def tr(text):
-    return QCoreApplication.translate("Style", text)
+    return QtCore.QCoreApplication.translate("Style", text)
 
 
 class StylePlugin(Plugin):
@@ -139,7 +142,7 @@ class StyleDialog(ExToolWindow):
         self.create_controls()
 
         self.save_action = QtWidgets.QAction(self)
-        self.save_action.setShortcut(QKeySequence.Save)
+        self.save_action.setShortcut(QtGui.QKeySequence.Save)
         self.save_action.triggered.connect(self.save)
         self.addAction(self.save_action)
 
@@ -223,7 +226,7 @@ class StyleDialog(ExToolWindow):
 
     def create_palette_colors(self):
         """Create the controls for editing the palette"""
-        layout = QGridLayout()
+        layout = QtWidgets.QGridLayout()
 
         # Create combobox simple/extended/full
         cbo = QComboBox()

--- a/hyperspyui/plugins/stylesheet.py
+++ b/hyperspyui/plugins/stylesheet.py
@@ -21,9 +21,9 @@ from hyperspyui.plugins.plugin import Plugin
 from functools import partial
 from collections import OrderedDict
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from pyqode.core import api
 from pyqode.core import modes
@@ -138,7 +138,7 @@ class StyleDialog(ExToolWindow):
                     i += 1
         self.create_controls()
 
-        self.save_action = QAction(self)
+        self.save_action = QtWidgets.QAction(self)
         self.save_action.setShortcut(QKeySequence.Save)
         self.save_action.triggered.connect(self.save)
         self.addAction(self.save_action)

--- a/hyperspyui/plugins/user_plugins/__init__.py
+++ b/hyperspyui/plugins/user_plugins/__init__.py
@@ -7,7 +7,7 @@ Created on Fri Dec 12 23:57:20 2014
 
 import os
 import glob
-modules = glob.glob(os.path.dirname(__file__) + "/*.py")
+modules = glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
 # modules.extend(glob.glob(os.path.dirname(__file__)+"/*.py?"))
 # TODO: In release form, we should support compiled plugins in pyc/pyo format
 __all__ = [os.path.splitext(os.path.basename(f))[0] for f in modules

--- a/hyperspyui/recorder.py
+++ b/hyperspyui/recorder.py
@@ -21,7 +21,7 @@ Created on Sat Feb 21 12:03:33 2015
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 from .plugincreator import create_plugin_code
 

--- a/hyperspyui/settings.py
+++ b/hyperspyui/settings.py
@@ -21,8 +21,8 @@ Created on Sat Dec 27 14:21:00 2014
 @author: Vidar Tonaas Fauske
 """
 
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy.QtCore import QSettings
+from qtpy.QtWidgets import QMessageBox
 
 from hyperspyui.widgets.extendedqwidgets import ExRememberPrompt
 

--- a/hyperspyui/settings.py
+++ b/hyperspyui/settings.py
@@ -21,9 +21,8 @@ Created on Sat Dec 27 14:21:00 2014
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.widgets.extendedqwidgets import ExRememberPrompt
 

--- a/hyperspyui/signalwrapper.py
+++ b/hyperspyui/signalwrapper.py
@@ -192,9 +192,6 @@ class SignalWrapper(Actionable):
                     self.signal_plot.restoreGeometry(self._sig_geom)
                 self._sig_geom = None
 
-            # Redraw plot needed for pyqt5
-            self.signal._plot.signal_plot.figure.canvas.draw_idle()
-
         if atleast_one_changed:
             self.mainwindow.check_action_selections()
 

--- a/hyperspyui/signalwrapper.py
+++ b/hyperspyui/signalwrapper.py
@@ -22,7 +22,7 @@ Created on Fri Oct 24 18:27:15 2014
 """
 
 from .util import fig2win
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 from .modelwrapper import ModelWrapper
 from .actionable import Actionable

--- a/hyperspyui/signalwrapper.py
+++ b/hyperspyui/signalwrapper.py
@@ -91,6 +91,9 @@ class SignalWrapper(Actionable):
         self._replotargs = (args, kwargs)
         self.mainwindow.main_frame.subWindowActivated.emit(
             self.mainwindow.main_frame.activeSubWindow())
+        # Redraw plot needed for pyqt5
+        if self.signal._plot and self.signal._plot.signal_plot:
+            self.signal._plot.signal_plot.figure.canvas.draw_idle()
 
     def _replot(self):
         if self.signal._plot is not None:
@@ -188,6 +191,9 @@ class SignalWrapper(Actionable):
                 if self._sig_geom is not None and self.signal_plot is not None:
                     self.signal_plot.restoreGeometry(self._sig_geom)
                 self._sig_geom = None
+
+            # Redraw plot needed for pyqt5
+            self.signal._plot.signal_plot.figure.canvas.draw_idle()
 
         if atleast_one_changed:
             self.mainwindow.check_action_selections()

--- a/hyperspyui/singleapplication.py
+++ b/hyperspyui/singleapplication.py
@@ -26,16 +26,16 @@ import sys
 import json
 import os
 import logging
-from python_qt_binding import QtGui, QtCore, QtNetwork, QT_BINDING
+from qtpy import QtGui, QtCore, QtNetwork, API, QtWidgets
 
 _logger = logging.getLogger(__name__)
 
 
-class SingleApplication(QtGui.QApplication):
-    messageAvailable = QtCore.pyqtSignal(object)
+class SingleApplication(QtWidgets.QApplication):
+    messageAvailable = QtCore.Signal(object)
 
     def __init__(self, argv, key):
-        QtGui.QApplication.__init__(self, argv)
+        QtWidgets.QApplication.__init__(self, argv)
         self._memory = QtCore.QSharedMemory(self)
         self._memory.setKey(key)
         if self._memory.attach():
@@ -48,7 +48,7 @@ class SingleApplication(QtGui.QApplication):
         # Set correct logo
         base_path = os.path.abspath(os.path.dirname(__file__))
         icon_path = os.path.join(base_path, 'images', 'hyperspy.svg')
-        QtGui.QApplication.setWindowIcon(QtGui.QIcon(icon_path))
+        QtWidgets.QApplication.setWindowIcon(QtGui.QIcon(icon_path))
 
     def isRunning(self):
         return self._running
@@ -94,7 +94,7 @@ class SingleApplicationWithMessaging(SingleApplication):
 
 def get_app(key):
     # send commandline args as message
-    if QT_BINDING == 'pyqt':
+    if "pyqt" in API:
         if len(sys.argv) > 1:
             app = SingleApplicationWithMessaging(sys.argv, key)
             if app.isRunning():
@@ -109,11 +109,11 @@ def get_app(key):
                 _logger.debug('An existing instance of HyperSpyUI is running, '
                               'bringing it to the front.')
                 sys.exit(1)     # An instance is already running
-    elif QT_BINDING == 'pyside':
+    elif API == 'pyside':
         from siding.singleinstance import QSingleApplication
         app = QSingleApplication(sys.argv)
         msg = json.dumps(sys.argv[1:])
         app.ensure_single(message=msg)
     else:
-        app = QtGui.QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
     return app

--- a/hyperspyui/smartcolorsvgiconengine.py
+++ b/hyperspyui/smartcolorsvgiconengine.py
@@ -22,15 +22,15 @@ Created on Wed Jul 29 18:09:56 2015
 """
 
 
-from python_qt_binding import QtGui, QtCore, QtSvg
-from QtCore import *
-from QtGui import *
-from QtSvg import *
+from qtpy import QtGui, QtCore, QtSvg, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
+from qtpy.QtSvg import *
 
 import re
 
 
-class SmartColorSVGIconEngine(QIconEngineV2):
+class SmartColorSVGIconEngine(QIconEngine):
     """
     This class is basically a port to Python from the code for Qt's
     QSvgIconEnginePlugin. On top of this has been added the ability to exchange

--- a/hyperspyui/smartcolorsvgiconengine.py
+++ b/hyperspyui/smartcolorsvgiconengine.py
@@ -23,14 +23,12 @@ Created on Wed Jul 29 18:09:56 2015
 
 
 from qtpy import QtGui, QtCore, QtSvg, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
-from qtpy.QtSvg import *
+from qtpy.QtGui import QPalette
 
 import re
 
 
-class SmartColorSVGIconEngine(QIconEngine):
+class SmartColorSVGIconEngine(QtGui.QIconEngine):
     """
     This class is basically a port to Python from the code for Qt's
     QSvgIconEnginePlugin. On top of this has been added the ability to exchange
@@ -55,7 +53,7 @@ class SmartColorSVGIconEngine(QIconEngine):
         self._addedPixmaps = {}
         self._svgFiles = {}
         self._svgBuffers = {}
-        self.default_key = (QIcon.Normal, QIcon.Off)
+        self.default_key = (QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.custom_color_replacements = {}
         self._automatic_color_replacements = {}
         self.use_qt_disabled = use_qt_disabled
@@ -66,7 +64,7 @@ class SmartColorSVGIconEngine(QIconEngine):
         """Sets `_automatic_color_replacements` attribute from application
         palette. Updates `_palette_key` to the cacheKey of the used palette.
         """
-        palette = QApplication.palette()
+        palette = QtWidgets.QApplication.palette()
         foreground = palette.color(QPalette.Active, QPalette.WindowText)
         background = palette.color(QPalette.Active, QPalette.Window)
         disabled_foreground = palette.color(QPalette.Disabled,
@@ -119,7 +117,7 @@ class SmartColorSVGIconEngine(QIconEngine):
         for old, new in color_table[color_key].items():
             re_exp = re.compile(re.escape(old), re.IGNORECASE)
             svg_cnt = re_exp.sub(new, svg_cnt)
-        out = QByteArray(svg_cnt)
+        out = QtCore.QByteArray(svg_cnt)
         return out
 
     def _loadDataForModeAndState(self, renderer, mode, state):
@@ -131,10 +129,10 @@ class SmartColorSVGIconEngine(QIconEngine):
         elif self.default_key in self._svgBuffers:
             buf = self._svgBuffers[self.default_key]
         else:
-            buf = QByteArray()
+            buf = QtCore.QByteArray()
 
         if buf:
-            buf = qUncompress(buf)
+            buf = QtCore.qUncompress(buf)
             renderer.load(buf)
         else:
             # If no buffer is available, load from file
@@ -143,7 +141,7 @@ class SmartColorSVGIconEngine(QIconEngine):
                 renderer.load(self._replace_in_stream(svgFile))
             elif self.default_key in self._svgFiles:
                 svgFile = self._svgFiles[self.default_key]
-                if mode == QIcon.Disabled:
+                if mode == QtGui.QIcon.Disabled:
                     renderer.load(self._replace_in_stream(svgFile, 'disabled'))
                 else:
                     renderer.load(self._replace_in_stream(svgFile))
@@ -159,16 +157,16 @@ class SmartColorSVGIconEngine(QIconEngine):
 
         pm = self.pixmap(size, mode, state)
         if pm is None:
-            return QSize()
+            return QtCore.QSize()
         return pm.size()
 
     def pixmap(self, size, mode, state):
         # Check if the palette has changed (if so invalidate cache)
-        if self._palette_key != QApplication.palette().cacheKey():
-            QPixmapCache.clear()
+        if self._palette_key != QtWidgets.QApplication.palette().cacheKey():
+            QtGui.QPixmapCache.clear()
             self._set_replacements_from_palette()
         pmckey = self._make_cache_key(size, mode, state)
-        pm = QPixmapCache.find(pmckey)
+        pm = QtGui.QPixmapCache.find(pmckey)
         if pm:
             return pm
 
@@ -177,30 +175,30 @@ class SmartColorSVGIconEngine(QIconEngine):
             if pm is not None and pm.size() == size:
                 return pm
 
-        renderer = QSvgRenderer()
+        renderer = QtSvg.QSvgRenderer()
         self._loadDataForModeAndState(renderer, mode, state)
         if not renderer.isValid():
-            return QPixmap()
+            return QtGui.QPixmap()
 
         actualSize = renderer.defaultSize()
         if actualSize is not None:
-            actualSize.scale(size, Qt.KeepAspectRatio)
+            actualSize.scale(size, QtCore.Qt.KeepAspectRatio)
 
-        img = QImage(actualSize, QImage.Format_ARGB32_Premultiplied)
+        img = QtGui.QImage(actualSize, QtGui.QImage.Format_ARGB32_Premultiplied)
         img.fill(0x00000000)
-        p = QPainter(img)
+        p = QtGui.QPainter(img)
         renderer.render(p)
         p.end()
-        pm = QPixmap.fromImage(img)
-        opt = QStyleOption()
-        opt.palette = QApplication.palette()
-        if self.use_qt_disabled or mode != QIcon.Disabled:
-            generated = QApplication.style().generatedIconPixmap(mode, pm, opt)
+        pm = QtGui.QPixmap.fromImage(img)
+        opt = QtWidgets.QStyleOption()
+        opt.palette = QtWidgets.QApplication.palette()
+        if self.use_qt_disabled or mode != QtGui.QIcon.Disabled:
+            generated = QtWidgets.QApplication.style().generatedIconPixmap(mode, pm, opt)
             if generated is not None:
                 pm = generated
 
         if pm is not None:
-            QPixmapCache.insert(pmckey, pm)
+            QtGui.QPixmapCache.insert(pmckey, pm)
 
         return pm
 
@@ -211,15 +209,15 @@ class SmartColorSVGIconEngine(QIconEngine):
         if fileName:
             abs = fileName
             if fileName[0] != ':':
-                abs = QFileInfo(fileName).absoluteFilePath()
+                abs = QtCore.QFileInfo(fileName).absoluteFilePath()
             al = abs.lower()
             if (al.endswith(".svg") or al.endswith(".svgz") or
                     al.endswith(".svg.gz")):
-                renderer = QSvgRenderer(abs)
+                renderer = QtSvg.QSvgRenderer(abs)
                 if renderer.isValid():
                     self._svgFiles[(mode, state)] = abs
             else:
-                pm = QPixmap(abs)
+                pm = QtGui.QPixmap(abs)
                 if pm is not None:
                     self.addPixmap(pm, mode, state)
 
@@ -233,33 +231,33 @@ class SmartColorSVGIconEngine(QIconEngine):
 
         self._svgBuffers = {}    # QHash<int, QByteArray>
 
-        if ds_in.version() >= QDataStream.Qt_4_4:
+        if ds_in.version() >= QtCore.QDataStream.Qt_4_4:
             nfiles = ds_in.readInt()
             fileNames = {}
             for i in range(nfiles):
                 fileNames[i] = ds_in.readString()
             isCompressed = ds_in.readBool()
             key = ds_in.readInt()
-            self._svgBuffers[key] = QByteArray()
+            self._svgBuffers[key] = QtCore.QByteArray()
             ds_in >> self._svgBuffers[key]
             if not isCompressed:
                 for key, v in self._svgBuffers.items():
-                    self._svgBuffers[key] = qCompress(v)
+                    self._svgBuffers[key] = QtCore.qCompress(v)
             hasAddedPixmaps = ds_in.readInt()
             if hasAddedPixmaps:
                 npixmaps = ds_in.readInt()
                 self._addedPixmaps = {}
                 for i in range(npixmaps):
-                    pm = QPixmap()
+                    pm = QtGui.QPixmap()
                     ds_in >> pm
                     self._addedPixmaps[i] = pm
         else:
-            pixmap = QPixmap()
-            data = QByteArray()
+            pixmap = QtGui.QPixmap()
+            data = QtCore.QByteArray()
 
             ds_in >> data
             if not data.isEmpty():
-                data = qUncompress(data)
+                data = QtCore.qUncompress(data)
                 if not data.isEmpty():
                     self._svgBuffers[self.default_key] = data
             num_entries = ds_in.readInt()
@@ -275,18 +273,18 @@ class SmartColorSVGIconEngine(QIconEngine):
         return True
 
     def write(self, ds_out):
-        if out.version() >= QDataStream.Qt_4_4:
+        if out.version() >= QtCore.QDataStream.Qt_4_4:
             isCompressed = 1
             if self._svgBuffers:
                 svgBuffers = self._svgBuffers
             else:
                 svgBuffers = {}     # QHash<int, QByteArray>
             for key, v in self._svgFiles.items():
-                buf = QByteArray()
-                f = QFile(v)
-                if f.open(QIODevice.ReadOnly):
+                buf = QtCore.QByteArray()
+                f = QtCore.QFile(v)
+                if f.open(QtCore.QIODevice.ReadOnly):
                     buf = f.readAll()
-                buf = qCompress(buf)
+                buf = QtCore.qCompress(buf)
                 svgBuffers[key] = buf
             out << self._svgFiles << isCompressed << svgBuffers
             if self._addedPixmaps:
@@ -294,16 +292,16 @@ class SmartColorSVGIconEngine(QIconEngine):
             else:
                 out << 0
         else:
-            buf = QByteArray()
+            buf = QtCore.QByteArray()
             if self._svgBuffers:
                 buf = self._svgBuffers[self.default_key]
             if buf.isEmpty():
                 svgFile = self._svgFiles[self.default_key]
                 if not svgFile.isEmpty():
-                    f = QFile(svgFile)
-                    if f.open(QIODevice.ReadOnly):
+                    f = QtCore.QFile(svgFile)
+                    if f.open(QtCore.QIODevice.ReadOnly):
                         buf = f.readAll()
-            buf = qCompress(buf)
+            buf = QtCore.qCompress(buf)
             out << buf
             # 4.3 has buggy handling of added pixmaps, so don't write any
             out << 0

--- a/hyperspyui/threaded.py
+++ b/hyperspyui/threaded.py
@@ -22,9 +22,8 @@ Created on Mon Nov 17 14:16:41 2014
 """
 
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import SIGNAL
 
 import types
 
@@ -32,10 +31,10 @@ from hyperspyui.exceptions import ProcessCanceled
 
 
 def tr(text):
-    return QCoreApplication.translate("Threaded", text)
+    return QtCore.QCoreApplication.translate("Threaded", text)
 
 
-class Worker(QObject):
+class Worker(QtCore.QObject):
     progress = QtCore.Signal(int)
     finished = QtCore.Signal()
     error = QtCore.Signal(str)
@@ -62,7 +61,7 @@ class Worker(QObject):
             raise
 
 
-class Threaded(QObject):
+class Threaded(QtCore.QObject):
 
     """
     Executes a user provided function in a new thread, and pops up a
@@ -83,7 +82,7 @@ class Threaded(QObject):
         super(Threaded, self).__init__(parent)
 
         # Create thread/objects
-        self.thread = QThread()
+        self.thread = QtCore.QThread()
         worker = Worker(run)
         worker.moveToThread(self.thread)
         Threaded.add_to_pool(self)
@@ -126,7 +125,7 @@ class ProgressThreaded(Threaded):
         self.generator_N = generator_N
 
         # Create progress bar.
-        progressbar = QProgressDialog(parent)
+        progressbar = QtWidgets.QProgressDialog(parent)
         if isinstance(run, types.GeneratorType):
             progressbar.setMinimum(0)
             if generator_N is None:

--- a/hyperspyui/threaded.py
+++ b/hyperspyui/threaded.py
@@ -22,9 +22,9 @@ Created on Mon Nov 17 14:16:41 2014
 """
 
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 import types
 

--- a/hyperspyui/threaded.py
+++ b/hyperspyui/threaded.py
@@ -23,7 +23,6 @@ Created on Mon Nov 17 14:16:41 2014
 
 
 from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import SIGNAL
 
 import types
 
@@ -155,11 +154,10 @@ class ProgressThreaded(Threaded):
         else:
             super(ProgressThreaded, self).__init__(parent, run, finished)
 
-        self.connect(self.thread, SIGNAL('started()'), self.display)
-        self.connect(self.worker, SIGNAL('finished()'), self.close)
-        self.connect(self.worker, SIGNAL('error()'), self.close)
-        self.connect(
-            self.worker, SIGNAL('progress(int)'), progressbar.setValue)
+        self.thread.started.connect(self.display)
+        self.worker.finished.connect(self.close)
+        self.worker.error.connect(self.close)
+        self.worker.progress[int].connect(progressbar.setValue)
         self.progressbar = progressbar
 
     def display(self):

--- a/hyperspyui/uiprogressbar.py
+++ b/hyperspyui/uiprogressbar.py
@@ -45,7 +45,7 @@ class Signaler(QObject):
     cancel = Signal(int)
     # This is necessary as it bugs out if not (it's a daisy chained event)
 
-    def _on_cancel(pid):
+    def _on_cancel(self, pid):
         signaler.cancel.emit(pid)
     on_cancel = _on_cancel
 

--- a/hyperspyui/uiprogressbar.py
+++ b/hyperspyui/uiprogressbar.py
@@ -28,7 +28,7 @@ from __future__ import division, absolute_import
 import sys
 from time import time
 
-from QtCore import QObject, Signal, SIGNAL
+from qtpy.QtCore import QObject, Signal, SIGNAL
 
 import hyperspy.external.progressbar
 from tqdm import tqdm

--- a/hyperspyui/util.py
+++ b/hyperspyui/util.py
@@ -199,7 +199,7 @@ def create_add_component_actions(parent, callback, prefix="", postfix=""):
         f = partial(callback, t)
         ac = QtWidgets.QAction(prefix + name + postfix, parent)
         ac.setStatusTip(tr("Add a component of type ") + name)
-        ac.connect(ac, QtCore.SIGNAL('triggered()'), f)
+        ac.triggered.connect(f)
         actions[ac_name] = ac
     return actions
 

--- a/hyperspyui/util.py
+++ b/hyperspyui/util.py
@@ -25,7 +25,7 @@ Created on Mon Oct 27 18:47:05 2014
 import hyperspy.components1d
 from hyperspy.misc.utils import slugify
 from functools import partial
-from python_qt_binding import QtGui, QtCore, QtSvg
+from qtpy import QtGui, QtCore, QtSvg, QtWidgets
 import os
 from contextlib import contextmanager
 
@@ -56,7 +56,7 @@ def lstrip(string, prefix):
 
 def debug_trace():
     '''Set a tracepoint in the Python debugger that works with Qt'''
-    from PyQt4.QtCore import pyqtRemoveInputHook
+    from qtpy.QtCore import pyqtRemoveInputHook
     from pdb import set_trace
     pyqtRemoveInputHook()
     set_trace()
@@ -197,7 +197,7 @@ def create_add_component_actions(parent, callback, prefix="", postfix=""):
             continue
         ac_name = 'add_component_' + name
         f = partial(callback, t)
-        ac = QtGui.QAction(prefix + name + postfix, parent)
+        ac = QtWidgets.QAction(prefix + name + postfix, parent)
         ac.setStatusTip(tr("Add a component of type ") + name)
         ac.connect(ac, QtCore.SIGNAL('triggered()'), f)
         actions[ac_name] = ac

--- a/hyperspyui/widgets/axespicker.py
+++ b/hyperspyui/widgets/axespicker.py
@@ -17,7 +17,8 @@
 # along with HyperSpyUI.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from qtpy import QtGui, QtCore
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtWidgets import QDialogButtonBox
 
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 
@@ -45,17 +46,17 @@ class AxesPickerDialog(ExToolWindow):
             return [i.data(QtCore.Qt.UserRole) for i in sel]
 
     def create_controls(self):
-        self.list = QtGui.QListWidget()
+        self.list = QtWidgets.QListWidget()
         for ax in self.signal.axes_manager._get_axes_in_natural_order():
             rep = '%s axis, size: %i' % (ax._get_name(), ax.size)
-            item = QtGui.QListWidgetItem(rep, self.list)
+            item = QtWidgets.QListWidgetItem(rep, self.list)
             item.setData(QtCore.Qt.UserRole, ax)
             self.list.addItem(item)
         if not self.single:
             self.list.setSelectionMode(
                 QtGui.QAbstractItemView.ExtendedSelection)
-        btns = QtGui.QDialogButtonBox(
-            QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel,
+        btns = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
             QtCore.Qt.Horizontal)
 
         btns.accepted.connect(self.accept)

--- a/hyperspyui/widgets/axespicker.py
+++ b/hyperspyui/widgets/axespicker.py
@@ -17,7 +17,7 @@
 # along with HyperSpyUI.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from python_qt_binding import QtGui, QtCore
+from qtpy import QtGui, QtCore
 
 from hyperspyui.widgets.extendedqwidgets import ExToolWindow
 

--- a/hyperspyui/widgets/colorpicker.py
+++ b/hyperspyui/widgets/colorpicker.py
@@ -17,7 +17,7 @@
 # along with HyperSpyUI.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from python_qt_binding import QtGui, QtCore
+from qtpy import QtGui, QtCore
 
 
 class ColorButton(QtGui.QPushButton):

--- a/hyperspyui/widgets/colorpicker.py
+++ b/hyperspyui/widgets/colorpicker.py
@@ -17,10 +17,10 @@
 # along with HyperSpyUI.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from qtpy import QtGui, QtCore
+from qtpy import QtGui, QtCore, QtWidgets
 
 
-class ColorButton(QtGui.QPushButton):
+class ColorButton(QtWidgets.QPushButton):
 
     colorChanged = QtCore.Signal([QtGui.QColor])
 

--- a/hyperspyui/widgets/contrastwidget.py
+++ b/hyperspyui/widgets/contrastwidget.py
@@ -115,7 +115,6 @@ class ContrastWidget(FigureWidget):
                 self.chk_log.setEnabled(False)
 
     def level_changed(self, value):
-        print('level changed!')
         self.lbl_level.setText(self.LevelLabel + ": %.2G" % value)
         p = self._cur_plot
         if p is not None:
@@ -126,7 +125,6 @@ class ContrastWidget(FigureWidget):
             p.update()
 
     def window_changed(self, value):
-        print('window changed!')
         self.lbl_window.setText(self.WindowLabel + ": %.2G" % value)
         p = self._cur_plot
         if p is not None:

--- a/hyperspyui/widgets/contrastwidget.py
+++ b/hyperspyui/widgets/contrastwidget.py
@@ -22,9 +22,9 @@ Created on Wed Oct 29 16:49:48 2014
 """
 
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from .extendedqwidgets import FigureWidget, ExDoubleSlider, ExClickLabel
 from hyperspy.misc.rgb_tools import rgbx2regular_array

--- a/hyperspyui/widgets/contrastwidget.py
+++ b/hyperspyui/widgets/contrastwidget.py
@@ -23,7 +23,6 @@ Created on Wed Oct 29 16:49:48 2014
 
 
 from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import SIGNAL
 
 from .extendedqwidgets import FigureWidget, ExDoubleSlider, ExClickLabel
 from hyperspy.misc.rgb_tools import rgbx2regular_array
@@ -116,6 +115,7 @@ class ContrastWidget(FigureWidget):
                 self.chk_log.setEnabled(False)
 
     def level_changed(self, value):
+        print('level changed!')
         self.lbl_level.setText(self.LevelLabel + ": %.2G" % value)
         p = self._cur_plot
         if p is not None:
@@ -126,6 +126,7 @@ class ContrastWidget(FigureWidget):
             p.update()
 
     def window_changed(self, value):
+        print('window changed!')
         self.lbl_window.setText(self.WindowLabel + ": %.2G" % value)
         p = self._cur_plot
         if p is not None:
@@ -185,12 +186,13 @@ class ContrastWidget(FigureWidget):
         self.chk_auto = QtWidgets.QCheckBox(tr("Auto"), self)
         self.chk_log = QtWidgets.QCheckBox(tr("Log"), self)
 
+        # Test level/window working?
         self.lbl_level.clicked.connect(self.reset_level)
         self.lbl_window.clicked.connect(self.reset_window)
         self.sl_level.valueChanged[float].connect(self.level_changed)
         self.sl_window.valueChanged[float].connect(self.window_changed)
-        self.connect(self.chk_auto, SIGNAL('stateChanged(int)'), self.auto)
-        self.connect(self.chk_log, SIGNAL('toggled(bool)'), self.log_changed)
+        self.chk_auto.stateChanged[int].connect(self.auto)
+        self.chk_log.toggled[bool].connect(self.log_changed)
 
         hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(self.chk_auto)

--- a/hyperspyui/widgets/contrastwidget.py
+++ b/hyperspyui/widgets/contrastwidget.py
@@ -187,8 +187,8 @@ class ContrastWidget(FigureWidget):
         # Test level/window working?
         self.lbl_level.clicked.connect(self.reset_level)
         self.lbl_window.clicked.connect(self.reset_window)
-        self.sl_level.valueChanged[float].connect(self.level_changed)
-        self.sl_window.valueChanged[float].connect(self.window_changed)
+        self.sl_level.double_valueChanged.connect(self.level_changed)
+        self.sl_window.double_valueChanged.connect(self.window_changed)
         self.chk_auto.stateChanged[int].connect(self.auto)
         self.chk_log.toggled[bool].connect(self.log_changed)
 

--- a/hyperspyui/widgets/contrastwidget.py
+++ b/hyperspyui/widgets/contrastwidget.py
@@ -22,9 +22,8 @@ Created on Wed Oct 29 16:49:48 2014
 """
 
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import SIGNAL
 
 from .extendedqwidgets import FigureWidget, ExDoubleSlider, ExClickLabel
 from hyperspy.misc.rgb_tools import rgbx2regular_array
@@ -35,7 +34,7 @@ from matplotlib.colors import Normalize, SymLogNorm
 
 
 def tr(text):
-    return QCoreApplication.translate("ContrastWidget", text)
+    return QtCore.QCoreApplication.translate("ContrastWidget", text)
 
 
 def _auto_contrast(plot):
@@ -64,7 +63,7 @@ class ContrastWidget(FigureWidget):
 
     def _on_figure_change(self, figure):
         super(ContrastWidget, self)._on_figure_change(figure)
-        if isinstance(figure, QMdiSubWindow):
+        if isinstance(figure, QtWidgets.QMdiSubWindow):
             figure = win2fig(figure)
 
         signals = self.parent().signals
@@ -174,17 +173,17 @@ class ContrastWidget(FigureWidget):
         self.sl_window.setValue(imax - imin)   # Will trigger events
 
     def create_controls(self):
-        self.sl_level = ExDoubleSlider(self, Qt.Horizontal)
+        self.sl_level = ExDoubleSlider(self, QtCore.Qt.Horizontal)
         self.lbl_level = ExClickLabel(self.LevelLabel + ": 0.0")
-        self.sl_window = ExDoubleSlider(self, Qt.Horizontal)
+        self.sl_window = ExDoubleSlider(self, QtCore.Qt.Horizontal)
         self.lbl_window = ExClickLabel(self.WindowLabel + ": 0.0")
 
         for sl in [self.sl_level, self.sl_window]:
             sl.setRange(0.0, 1.0)
             sl.setValue(0.0)
 
-        self.chk_auto = QCheckBox(tr("Auto"), self)
-        self.chk_log = QCheckBox(tr("Log"), self)
+        self.chk_auto = QtWidgets.QCheckBox(tr("Auto"), self)
+        self.chk_log = QtWidgets.QCheckBox(tr("Log"), self)
 
         self.lbl_level.clicked.connect(self.reset_level)
         self.lbl_window.clicked.connect(self.reset_window)
@@ -193,16 +192,16 @@ class ContrastWidget(FigureWidget):
         self.connect(self.chk_auto, SIGNAL('stateChanged(int)'), self.auto)
         self.connect(self.chk_log, SIGNAL('toggled(bool)'), self.log_changed)
 
-        hbox = QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(self.chk_auto)
         hbox.addWidget(self.chk_log)
-        vbox = QVBoxLayout()
+        vbox = QtWidgets.QVBoxLayout()
         for w in [self.sl_level, self.lbl_level,
                   self.sl_window, self.lbl_window]:
             vbox.addWidget(w)
         vbox.addLayout(hbox)
 
-        wrap = QWidget()
+        wrap = QtWidgets.QWidget()
         wrap.setLayout(vbox)
         height = vbox.sizeHint().height()
         wrap.setFixedHeight(height)

--- a/hyperspyui/widgets/dataviewwidget.py
+++ b/hyperspyui/widgets/dataviewwidget.py
@@ -23,9 +23,9 @@ Created on Tue Nov 04 16:32:55 2014
 
 import os
 
-from python_qt_binding import QtGui, QtCore, QtSvg
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtSvg, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from functools import partial
 import traits.api as t
@@ -321,13 +321,13 @@ class DataViewWidget(QWidget):
             model = item.parent().data(NameCol, Qt.UserRole)
 
             # Fit action
-            ac = QAction(tr("&Fit component"), self.tree)
+            ac = QtWidgets.QAction(tr("&Fit component"), self.tree)
             f = partial(model.fit_component, comp)
             self.connect(ac, SIGNAL('triggered()'), f)
             cm.addAction(ac)
 
             # Configure action
-            ac = QAction(tr("&Configure"), self.tree)
+            ac = QtWidgets.QAction(tr("&Configure"), self.tree)
             f = partial(self.edit_traits, comp)
             ac.triggered.connect(f)
             cm.addAction(ac)
@@ -335,7 +335,7 @@ class DataViewWidget(QWidget):
             cm.addSeparator()
 
             # Remove action
-            ac = QAction(tr("&Delete"), self.tree)
+            ac = QtWidgets.QAction(tr("&Delete"), self.tree)
             f = partial(model.remove_component, comp)
             self.connect(ac, SIGNAL('triggered()'), f)
             cm.addAction(ac)

--- a/hyperspyui/widgets/dataviewwidget.py
+++ b/hyperspyui/widgets/dataviewwidget.py
@@ -24,7 +24,7 @@ Created on Tue Nov 04 16:32:55 2014
 import os
 
 from qtpy import QtGui, QtCore, QtSvg, QtWidgets
-from qtpy.QtCore import Qt, SIGNAL
+from qtpy.QtCore import Qt, Signal
 
 from functools import partial
 import traits.api as t
@@ -198,8 +198,7 @@ class DataViewWidget(QtWidgets.QWidget):
         self.tree.setSizePolicy(sp)
 
         self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.connect(self.tree, SIGNAL('customContextMenuRequested(QtCore.QPoint)'),
-                     self.onCustomContextMenu)
+        self.tree.customContextMenuRequested[QtCore.QPoint].connect(self.onCustomContextMenu)
         self.tree.currentItemChanged.connect(self.currentItemChanged)
         self.tree.itemDoubleClicked.connect(self.itemDoubleClicked)
 
@@ -322,7 +321,7 @@ class DataViewWidget(QtWidgets.QWidget):
             # Fit action
             ac = QtWidgets.QAction(tr("&Fit component"), self.tree)
             f = partial(model.fit_component, comp)
-            self.connect(ac, SIGNAL('triggered()'), f)
+            ac.triggered.connect(f)
             cm.addAction(ac)
 
             # Configure action
@@ -336,7 +335,7 @@ class DataViewWidget(QtWidgets.QWidget):
             # Remove action
             ac = QtWidgets.QAction(tr("&Delete"), self.tree)
             f = partial(model.remove_component, comp)
-            self.connect(ac, SIGNAL('triggered()'), f)
+            ac.triggered.connect(f)
             cm.addAction(ac)
         cm.exec_(self.tree.mapToGlobal(point))
 

--- a/hyperspyui/widgets/editorwidget.py
+++ b/hyperspyui/widgets/editorwidget.py
@@ -21,9 +21,9 @@ Created on Sat Feb 21 17:55:01 2015
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 import os
 
@@ -207,12 +207,12 @@ class EditorWidget(ExToolWindow):
 
         self.create_controls(path)
 
-        self.save_action = QAction(self)
+        self.save_action = QtWidgets.QAction(self)
         self.save_action.setShortcut(QKeySequence.Save)
         self.save_action.triggered.connect(self.save)
         self.addAction(self.save_action)
 
-        self.run_action = QAction(self)
+        self.run_action = QtWidgets.QAction(self)
         self.run_action.setShortcut(QKeySequence(Qt.Key_F5))
         self.run_action.triggered.connect(self.run)
         self.addAction(self.run_action)

--- a/hyperspyui/widgets/editorwidget.py
+++ b/hyperspyui/widgets/editorwidget.py
@@ -22,8 +22,9 @@ Created on Sat Feb 21 17:55:01 2015
 """
 
 from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy.QtWidgets import (QDialogButtonBox, QCheckBox, QLineEdit, 
+                            QPushButton, QHBoxLayout, QVBoxLayout, QFormLayout,
+                            )
 
 import os
 
@@ -40,7 +41,7 @@ import hyperspyui.plugincreator as pc
 
 
 def tr(text):
-    return QCoreApplication.translate("EditorWidget", text)
+    return QtCore.QCoreApplication.translate("EditorWidget", text)
 
 
 class NameCategoryPrompt(ExToolWindow):
@@ -65,7 +66,7 @@ class NameCategoryPrompt(ExToolWindow):
         self.btn_browse_icon.setEnabled(icon)
 
     def browse_icon(self):
-        formats = QImageReader.supportedImageFormats()
+        formats = QtGui.QImageReader.supportedImageFormats()
         formats = [str(f, encoding='ascii') for f in formats]
         # Add one filter that takes all supported:
         type_filter = tr("Supported formats")
@@ -73,10 +74,10 @@ class NameCategoryPrompt(ExToolWindow):
         # Add all as individual options
         type_filter += ';;' + tr("All files") + \
             ' (*.*) ;;*.' + ';;*.'.join(formats)
-        path = QFileDialog.getOpenFileName(self,
-                                           tr("Pick icon"),
-                                           os.path.dirname(self.ui.cur_dir),
-                                           type_filter)
+        path = QtWidgets.QFileDialog.getOpenFileName(self,
+            tr("Pick icon"),
+            os.path.dirname(self.ui.cur_dir),
+            type_filter)
         if isinstance(path, tuple):    # Pyside returns tuple, PyQt not
             path = path[0]
         if path is None:
@@ -97,7 +98,7 @@ class NameCategoryPrompt(ExToolWindow):
         self.txt_iconpath.setEnabled(False)
         self.btn_browse_icon.setEnabled(False)
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
-                                Qt.Horizontal)
+                                QtCore.Qt.Horizontal)
 
         self.chk_menu.toggled.connect(self.checks_changed)
         self.chk_toolbar.toggled.connect(self.checks_changed)
@@ -208,12 +209,12 @@ class EditorWidget(ExToolWindow):
         self.create_controls(path)
 
         self.save_action = QtWidgets.QAction(self)
-        self.save_action.setShortcut(QKeySequence.Save)
+        self.save_action.setShortcut(QtGui.QKeySequence.Save)
         self.save_action.triggered.connect(self.save)
         self.addAction(self.save_action)
 
         self.run_action = QtWidgets.QAction(self)
-        self.run_action.setShortcut(QKeySequence(Qt.Key_F5))
+        self.run_action.setShortcut(QtGui.QKeySequence(QtCore.Qt.Key_F5))
         self.run_action.triggered.connect(self.run)
         self.addAction(self.run_action)
 
@@ -242,7 +243,7 @@ class EditorWidget(ExToolWindow):
         text = self.editor.toPlainText()
         if len(text) > 0 and text[-1] == '\n':
             prev_cursor = self.editor.textCursor()
-            self.editor.moveCursor(QTextCursor.End)
+            self.editor.moveCursor(QtGui.QTextCursor.End)
             self.editor.insertPlainText(code)
             self.editor.setTextCursor(prev_cursor)
         else:
@@ -251,7 +252,7 @@ class EditorWidget(ExToolWindow):
     def make_plugin(self):
         diag = NameCategoryPrompt(self.ui, self)
         dr = diag.exec_()
-        if dr == QDialog.Accepted:
+        if dr == QtWidgets.QDialog.Accepted:
             if diag.chk_icon.isChecked():
                 icon = diag.txt_iconpath.text()
             else:
@@ -274,7 +275,7 @@ class EditorWidget(ExToolWindow):
                                     '.py')
             e = EditorWidget(self.ui, self.ui, path)
             e.append_code(code)
-            e.editor.moveCursor(QTextCursor.Start)
+            e.editor.moveCursor(QtGui.QTextCursor.Start)
             e.editor.ensureCursorVisible()
             self.ui.editors.append(e)   # We have to keep an instance!
             e.finished.connect(lambda: self.ui.editors.remove(e))
@@ -289,9 +290,9 @@ class EditorWidget(ExToolWindow):
 
     def save(self):
         if not os.path.isfile(self.editor.file.path):
-            path = QFileDialog.getSaveFileName(self,
-                                               tr("Choose destination path"),
-                                               self.editor.file.path)[0]
+            path = QtWidgets.QFileDialog.getSaveFileName(self,
+                tr("Choose destination path"),
+                self.editor.file.path)[0]
             if not path:
                 return False
             self.editor.file._path = path
@@ -313,9 +314,9 @@ class EditorWidget(ExToolWindow):
         # Default size to fit right margin
         def_sz = super(EditorWidget, self).sizeHint()
         if hasattr(self, 'editor'):
-            font = QFont(self.editor.font_name, self.editor.font_size +
-                         self.editor.zoom_level)
-            metrics = QFontMetricsF(font)
+            font = QtGui.QFont(self.editor.font_name, self.editor.font_size +
+                               self.editor.zoom_level)
+            metrics = QtGui.QFontMetricsF(font)
             pos = 80
             cm = self.layout().contentsMargins()
             # TODO: Currently uses manual, magic number. Do properly!

--- a/hyperspyui/widgets/elementpicker.py
+++ b/hyperspyui/widgets/elementpicker.py
@@ -360,7 +360,7 @@ class ElementPickerWidget(FigureWidget):
                 continue
             w.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
             f = partial(self.element_context, w)
-            self.connect(w, QtCore.SIGNAL('customContextMenuRequested(QtCore.QPoint)'), f)
+            w.customContextMenuRequested[QtCore.QPoint].connect(f)
 
         self.chk_markers = QtWidgets.QCheckBox(tr("Markers"))
         self.chk_markers.toggled[bool].connect(self._on_toggle_markers)

--- a/hyperspyui/widgets/elementpicker.py
+++ b/hyperspyui/widgets/elementpicker.py
@@ -23,9 +23,9 @@ Created on Fri Nov 21 22:22:33 2014
 
 from functools import partial
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 import hyperspy.signals
 from hyperspy.misc.elements import elements as elements_db

--- a/hyperspyui/widgets/elementpicker.py
+++ b/hyperspyui/widgets/elementpicker.py
@@ -23,9 +23,7 @@ Created on Fri Nov 21 22:22:33 2014
 
 from functools import partial
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
 
 import hyperspy.signals
 from hyperspy.misc.elements import elements as elements_db
@@ -36,7 +34,7 @@ from hyperspyui.util import win2sig, block_signals
 
 
 def tr(text):
-    return QCoreApplication.translate("ElementPickerWidget", text)
+    return QtCore.QCoreApplication.translate("ElementPickerWidget", text)
 
 edstypes = (hyperspy.signals.EDSSEMSpectrum, hyperspy.signals.EDSTEMSpectrum)
 
@@ -47,7 +45,7 @@ class ElementPickerWidget(FigureWidget):
     Tool window for picking elements of an interactive periodic table.
     Takes a signal in the constructor, and a parent control.
     """
-    element_toggled = Signal(str)
+    element_toggled = QtCore.Signal(str)
 
     def __init__(self, main_window, parent):
         super(ElementPickerWidget, self).__init__(main_window, parent)
@@ -338,7 +336,7 @@ class ElementPickerWidget(FigureWidget):
     def element_context(self, widget, point):
         if not self.isEDS():
             return
-        cm = QMenu()
+        cm = QtWidgets.QMenu()
         element = widget.text()
         active, possible = self._get_element_subshells(element)
         for ss in possible:
@@ -360,23 +358,23 @@ class ElementPickerWidget(FigureWidget):
         for w in self.table.children():
             if not isinstance(w, ExClickLabel):
                 continue
-            w.setContextMenuPolicy(Qt.CustomContextMenu)
+            w.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
             f = partial(self.element_context, w)
-            self.connect(w, SIGNAL('customContextMenuRequested(QPoint)'), f)
+            self.connect(w, QtCore.SIGNAL('customContextMenuRequested(QtCore.QPoint)'), f)
 
-        self.chk_markers = QCheckBox(tr("Markers"))
+        self.chk_markers = QtWidgets.QCheckBox(tr("Markers"))
         self.chk_markers.toggled[bool].connect(self._on_toggle_markers)
-        self.map_btn = QPushButton(tr("Map"))
+        self.map_btn = QtWidgets.QPushButton(tr("Map"))
         self.map_btn.clicked.connect(self.make_map)
 
-        vbox = QVBoxLayout()
+        vbox = QtWidgets.QVBoxLayout()
         vbox.addWidget(self.table)
 
-        hbox = QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.addWidget(self.chk_markers)
         hbox.addWidget(self.map_btn)
         vbox.addLayout(hbox)
 
-        w = QWidget()
+        w = QtWidgets.QWidget()
         w.setLayout(vbox)
         self.setWidget(w)

--- a/hyperspyui/widgets/extendedqwidgets.py
+++ b/hyperspyui/widgets/extendedqwidgets.py
@@ -147,7 +147,7 @@ class ExDoubleSlider(QtWidgets.QSlider):
             super(ExDoubleSlider, self).__init__(orientation, parent)
         self.steps = 1000
         self._range = (0.0, 1.0)
-        self.connect(self, QtCore.SIGNAL('valueChanged(int)'), self._on_change)
+        self.valueChanged.connect(self._on_change)
 
     def setRange(self, vmin, vmax):
         if isinstance(vmin, (np.complex64, np.complex128)):

--- a/hyperspyui/widgets/extendedqwidgets.py
+++ b/hyperspyui/widgets/extendedqwidgets.py
@@ -21,19 +21,16 @@ Created on Fri Nov 21 22:11:04 2014
 @author: Vidar Tonaas Fauske
 """
 
-from  qtpy import QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
-from qtpy.QtWidgets import *
+from qtpy import QtCore, QtWidgets
 
 import numpy as np
 
 
 def tr(text):
-    return QCoreApplication.translate("ExtendedQWidgets", text)
+    return QtCore.QCoreApplication.translate("ExtendedQWidgets", text)
 
 
-class ExToolWindow(QDialog):
+class ExToolWindow(QtWidgets.QDialog):
 
     """
     QDialog with Qt.Tool window flags.
@@ -41,10 +38,10 @@ class ExToolWindow(QDialog):
 
     def __init__(self, parent=None):
         super(ExToolWindow, self).__init__(parent)
-        self.setWindowFlags(Qt.Tool)
+        self.setWindowFlags(QtCore.Qt.Tool)
 
 
-class FigureWidget(QDockWidget):
+class FigureWidget(QtWidgets.QDockWidget):
 
     def __init__(self, main_window, parent=None):
         super(FigureWidget, self).__init__(parent)
@@ -84,26 +81,26 @@ class FigureWidget(QDockWidget):
             self._on_figure_change(self._last_window)
 
 
-class ExClickLabel(QLabel):
+class ExClickLabel(QtWidgets.QLabel):
 
     """
     QLabel with 'clicked()' signal.
     """
-    clicked = Signal()
+    clicked = QtCore.Signal()
 
     def mouseReleaseEvent(self, event):
-        if event.button() == Qt.LeftButton:
+        if event.button() == QtCore.Qt.LeftButton:
             self.clicked.emit()
         super(ExClickLabel, self).mouseReleaseEvent(event)
 
 
-class ExMessageBox(QMessageBox):
+class ExMessageBox(QtWidgets.QMessageBox):
 
     def isChecked(self):
         cb = self.checkBox()
         if cb is None:
             raise AttributeError
-        return cb.checkState() == Qt.Checked
+        return cb.checkState() == QtCore.Qt.Checked
 
     def setCheckBox(self, cb):
         try:
@@ -115,7 +112,7 @@ class ExMessageBox(QMessageBox):
             self._checkBox = cb
             if cb is not None:
                 cb.blockSignals(True)
-                self.addButton(cb, QMessageBox.ResetRole)
+                self.addButton(cb, QtWidgets.QMessageBox.ResetRole)
 
     def checkBox(self):
         try:
@@ -132,11 +129,11 @@ class ExRememberPrompt(ExMessageBox):
 
     def __init__(self, *args, **kwargs):
         super(ExRememberPrompt, self).__init__(*args, **kwargs)
-        cb = QCheckBox(tr("Remember this choice"))
+        cb = QtWidgets.QCheckBox(tr("Remember this choice"))
         self.setCheckBox(cb)
 
 
-class ExDoubleSlider(QSlider):
+class ExDoubleSlider(QtWidgets.QSlider):
 
     """
     QSlider with double values instead of int values.
@@ -150,7 +147,7 @@ class ExDoubleSlider(QSlider):
             super(ExDoubleSlider, self).__init__(orientation, parent)
         self.steps = 1000
         self._range = (0.0, 1.0)
-        self.connect(self, SIGNAL('valueChanged(int)'), self._on_change)
+        self.connect(self, QtCore.SIGNAL('valueChanged(int)'), self._on_change)
 
     def setRange(self, vmin, vmax):
         if isinstance(vmin, (np.complex64, np.complex128)):

--- a/hyperspyui/widgets/extendedqwidgets.py
+++ b/hyperspyui/widgets/extendedqwidgets.py
@@ -21,9 +21,10 @@ Created on Fri Nov 21 22:11:04 2014
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from  qtpy import QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
+from qtpy.QtWidgets import *
 
 import numpy as np
 

--- a/hyperspyui/widgets/extendedqwidgets.py
+++ b/hyperspyui/widgets/extendedqwidgets.py
@@ -138,7 +138,7 @@ class ExDoubleSlider(QtWidgets.QSlider):
     """
     QSlider with double values instead of int values.
     """
-    valueChanged = QtCore.Signal(float)
+    double_valueChanged = QtCore.Signal(float)
 
     def __init__(self, parent=None, orientation=None):
         if orientation is None:
@@ -178,4 +178,4 @@ class ExDoubleSlider(QtWidgets.QSlider):
 
     def _on_change(self, intval):
         dblval = self._int2dbl(intval)
-        self.valueChanged.emit(dblval)
+        self.double_valueChanged.emit(dblval)

--- a/hyperspyui/widgets/flowlayout.py
+++ b/hyperspyui/widgets/flowlayout.py
@@ -33,7 +33,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
 """
 
-from python_qt_binding import QtCore, QtGui
+from qtpy import QtCore, QtGui
 
 
 class FlowLayout(QtGui.QLayout):

--- a/hyperspyui/widgets/flowlayout.py
+++ b/hyperspyui/widgets/flowlayout.py
@@ -33,7 +33,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
 """
 
-from qtpy import QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class FlowLayout(QtGui.QLayout):
@@ -54,14 +54,14 @@ class FlowLayout(QtGui.QLayout):
             return self._hSpace
         else:
             return self._smartSpacing(
-                QtGui.QStyle.PM_LayoutHorizontalSpacing)
+                QtWidgets.QStyle.PM_LayoutHorizontalSpacing)
 
     def verticalSpacing(self):
         if self._vSpace >= 0:
             return self._vSpace
         else:
             return self._smartSpacing(
-                QtGui.QStyle.PM_LayoutVerticalSpacing)
+                QtWidgets.QStyle.PM_LayoutVerticalSpacing)
 
     def expandingDirections(self):
         return QtCore.Qt.Orientation(0)
@@ -116,14 +116,14 @@ class FlowLayout(QtGui.QLayout):
             spaceX = self.horizontalSpacing()
             if spaceX == -1:
                 spaceX = w.style().layoutSpacing(
-                    QtGui.QSizePolicy.PushButton,
-                    QtGui.QSizePolicy.PushButton,
+                    QtWidgets.QSizePolicy.PushButton,
+                    QtWidgets.QSizePolicy.PushButton,
                     QtCore.Qt.Horizontal)
             spaceY = self.verticalSpacing()
             if spaceY == -1:
                 spaceY = w.style().layoutSpacing(
-                    QtGui.QSizePolicy.PushButton,
-                    QtGui.QSizePolicy.PushButton,
+                    QtWidgets.QSizePolicy.PushButton,
+                    QtWidgets.QSizePolicy.PushButton,
                     QtCore.Qt.Vertical)
             nextX = x + item.sizeHint().width() + spaceX
             if (nextX - spaceX > effectiveRect.right() and

--- a/hyperspyui/widgets/periodictable.py
+++ b/hyperspyui/widgets/periodictable.py
@@ -21,9 +21,9 @@ Created on Fri Nov 21 19:31:50 2014
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from functools import partial
 from hyperspyui._elements import elements

--- a/hyperspyui/widgets/periodictable.py
+++ b/hyperspyui/widgets/periodictable.py
@@ -21,9 +21,8 @@ Created on Fri Nov 21 19:31:50 2014
 @author: Vidar Tonaas Fauske
 """
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Qt
 
 from functools import partial
 from hyperspyui._elements import elements
@@ -31,11 +30,11 @@ from .extendedqwidgets import ExClickLabel
 
 
 def tr(text):
-    return QCoreApplication.translate("PeriodicTable", text)
+    return QtCore.QCoreApplication.translate("PeriodicTable", text)
 
 
-class PeriodicTableWidget(QWidget):
-    element_toggled = Signal(str)
+class PeriodicTableWidget(QtWidgets.QWidget):
+    element_toggled = QtCore.Signal(str)
 
     def __init__(self, parent=None):
         super(PeriodicTableWidget, self).__init__(parent)
@@ -52,7 +51,7 @@ class PeriodicTableWidget(QWidget):
             j = 0
             for e in row:
                 if isinstance(e, tuple):
-                    w = QLabel(e[1], self)
+                    w = QtWidgets.QLabel(e[1], self)
                     grid.addWidget(w, i, j, 1, e[0], Qt.AlignRight)
                     j += e[0]
                 elif isinstance(e, dict):
@@ -118,10 +117,10 @@ class PeriodicTableWidget(QWidget):
         self.element_toggled.emit(value['id'])
 
     def sizeHint(self):
-        return QSize(310, 140)
+        return QtCore.QSize(310, 140)
 
     def create_controls(self):
-        grid = QGridLayout(self)
+        grid = QtWidgets.QGridLayout(self)
         grid.setSpacing(0)
         grid.setContentsMargins(0, 0, 0, 0)
         self.parse_elements(grid)

--- a/hyperspyui/widgets/pickxsignals.py
+++ b/hyperspyui/widgets/pickxsignals.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpyUI.  If not, see <http://www.gnu.org/licenses/>.
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.widgets.signallist import SignalList
 

--- a/hyperspyui/widgets/pickxsignals.py
+++ b/hyperspyui/widgets/pickxsignals.py
@@ -16,19 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpyUI.  If not, see <http://www.gnu.org/licenses/>.
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtWidgets
 
 from hyperspyui.widgets.signallist import SignalList
 
 
-class PickXSignalsWidget(QWidget):
+class PickXSignalsWidget(QtWidgets.QWidget):
 
     def __init__(self, signal_wrappers, x, parent=None, titles=None,
                  wrap_col=4):
         super(PickXSignalsWidget, self).__init__(parent)
-        grid = QGridLayout()
+        grid = QtWidgets.QGridLayout()
         self.pickers = []
         self._x = x
         self._sws = signal_wrappers
@@ -42,7 +40,7 @@ class PickXSignalsWidget(QWidget):
 
         for i in range(x):
             picker = SignalList(signal_wrappers, self, False)
-            grid.addWidget(QLabel(titles[i]), 2*(i // wrap_col),
+            grid.addWidget(QtWidgets.QLabel(titles[i]), 2*(i // wrap_col),
                            i % wrap_col)
             grid.addWidget(picker, 1 + 2*(i // wrap_col), i % wrap_col)
             self.pickers.append(picker)

--- a/hyperspyui/widgets/pluginmanagerwidget.py
+++ b/hyperspyui/widgets/pluginmanagerwidget.py
@@ -24,19 +24,20 @@ Created on Sun Mar 01 03:24:48 2015
 import sys
 import os
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore
+from qtpy.QtCore import Qt, QModelIndex
+from qtpy.QtWidgets import (QDialogButtonBox, QTableView, QHeaderView,
+                            QPushButton, QVBoxLayout)
 
 from .extendedqwidgets import ExToolWindow
 from .editorwidget import EditorWidget
 
 
 def tr(text):
-    return QCoreApplication.translate("PluginManagerWidget", text)
+    return QtCore.QCoreApplication.translate("PluginManagerWidget", text)
 
 
-class PluginsModel(QAbstractItemModel):
+class PluginsModel(QtCore.QAbstractItemModel):
 
     EnabledColumn = 0
     NameColumn = 1
@@ -114,10 +115,10 @@ class PluginsModel(QAbstractItemModel):
                     return tr("Path")
         return None
 
-    def rowCount(self, parent=QModelIndex()):
+    def rowCount(self, parent=QtCore.QModelIndex()):
         return len(self._plugin_data)
 
-    def columnCount(self, parent=QModelIndex()):
+    def columnCount(self, parent=QtCore.QModelIndex()):
         return 3
 
 

--- a/hyperspyui/widgets/pluginmanagerwidget.py
+++ b/hyperspyui/widgets/pluginmanagerwidget.py
@@ -24,9 +24,9 @@ Created on Sun Mar 01 03:24:48 2015
 import sys
 import os
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from .extendedqwidgets import ExToolWindow
 from .editorwidget import EditorWidget

--- a/hyperspyui/widgets/settingsdialog.py
+++ b/hyperspyui/widgets/settingsdialog.py
@@ -23,9 +23,12 @@ Created on Sun Mar 01 18:26:38 2015
 
 from functools import partial
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore
+from qtpy.QtCore import QSettings
+from qtpy.QtWidgets import (QDialogButtonBox, QVBoxLayout, QLineEdit, QWidget,
+                            QCheckBox, QDoubleSpinBox, QSpinBox, QComboBox,
+                            QMessageBox, QAbstractButton,
+                            QTabWidget, QFormLayout)
 
 from .extendedqwidgets import ExToolWindow
 from hyperspyui.settings import Settings
@@ -34,11 +37,11 @@ import numpy as np
 
 
 def tr(text):
-    return QCoreApplication.translate("PluginManagerWidget", text)
+    return QtCore.QCoreApplication.translate("PluginManagerWidget", text)
 
 
 class SettingsDialog(ExToolWindow):
-    settings_changed = Signal(dict)
+    settings_changed = QtCore.Signal(dict)
 
     def __init__(self, main_window, parent=None):
         """
@@ -70,7 +73,7 @@ class SettingsDialog(ExToolWindow):
             v = widget.text()
         elif isinstance(widget, QCheckBox):
             if widget.isTristate() and \
-                    widget.checkState() == Qt.PartiallyChecked:
+                    widget.checkState() == QtCore.Qt.PartiallyChecked:
                 v = None
             else:
                 v = "true" if widget.isChecked() else "false"
@@ -274,7 +277,7 @@ class SettingsDialog(ExToolWindow):
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Apply |
                                 QDialogButtonBox.Cancel |
                                 QDialogButtonBox.Reset,
-                                Qt.Horizontal, self)
+                                QtCore.Qt.Horizontal, self)
         btns.accepted.connect(self._on_accept)
         btns.rejected.connect(self.reject)
         btns.clicked[QAbstractButton].connect(self._on_click)

--- a/hyperspyui/widgets/settingsdialog.py
+++ b/hyperspyui/widgets/settingsdialog.py
@@ -23,9 +23,9 @@ Created on Sun Mar 01 18:26:38 2015
 
 from functools import partial
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from .extendedqwidgets import ExToolWindow
 from hyperspyui.settings import Settings

--- a/hyperspyui/widgets/signallist.py
+++ b/hyperspyui/widgets/signallist.py
@@ -22,9 +22,9 @@ Created on Mon Oct 27 23:09:55 2014
 """
 
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 from hyperspyui.bindinglist import BindingList
 

--- a/hyperspyui/widgets/signallist.py
+++ b/hyperspyui/widgets/signallist.py
@@ -22,14 +22,13 @@ Created on Mon Oct 27 23:09:55 2014
 """
 
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from hyperspyui.bindinglist import BindingList
 
 
-class SignalList(QListWidget):
+class SignalList(QtWidgets.QListWidget):
 
     def __init__(self, items=None, parent=None, multiselect=True):
         super(SignalList, self).__init__(parent)
@@ -50,9 +49,9 @@ class SignalList(QListWidget):
     def multiselect(self, value):
         self._multiselect = value
         if value:
-            self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+            self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         else:
-            self.setSelectionMode(QAbstractItemView.SingleSelection)
+            self.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
 
     def bind(self, blist):
         blist.add_target(self)
@@ -67,7 +66,7 @@ class SignalList(QListWidget):
             self.unbind(b)
 
     def addItem(self, object):
-        item = QListWidgetItem(object.name, self)
+        item = QtWidgets.QListWidgetItem(object.name, self)
         item.setData(Qt.UserRole, object)
         super(SignalList, self).addItem(item)
 
@@ -76,14 +75,14 @@ class SignalList(QListWidget):
             self.addItem(i)
 
     def insertItem(self, index, object):
-        item = QListWidgetItem(object.name, self)
+        item = QtWidgets.QListWidgetItem(object.name, self)
         item.setData(Qt.UserRole, object)
         super(SignalList, self).insertItem(index, item)
 
     def signal(self, index):
         if isinstance(index, int):
             return self.item(index).data(Qt.UserRole)
-        elif isinstance(index, QListWidgetItem):
+        elif isinstance(index, QtWidgets.QListWidgetItem):
             return index.data(Qt.UserRole)
 
     def get_selected(self):
@@ -98,5 +97,5 @@ class SignalList(QListWidget):
                 return None
 
     def __getitem__(self, key):
-        if isinstance(key, QListWidgetItem):
+        if isinstance(key, QtWidgets.QListWidgetItem):
             return key.data(Qt.UserRole)

--- a/hyperspyui/widgets/stringinput.py
+++ b/hyperspyui/widgets/stringinput.py
@@ -21,42 +21,42 @@ Created on Wed Jan 20 02:43:41 2016
 @author: Vidar Tonaas Fauske
 """
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QDialogButtonBox
 
 
-class StringInputDialog(QDialog):
+class StringInputDialog(QtWidgets.QDialog):
 
     def __init__(self, prompt="", default="", parent=None):
         super(StringInputDialog, self).__init__(parent=parent)
         self.setWindowTitle("Input prompt")
-        self.setWindowFlags(Qt.Tool)
+        self.setWindowFlags(QtCore.Qt.Tool)
 
-        frm = QFormLayout()
-        self.edit = QLineEdit(default)
+        frm = QtWidgets.QFormLayout()
+        self.edit = QtWidgets.QLineEdit(default)
         frm.addRow(prompt, self.edit)
 
-        btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
-                                Qt.Horizontal, self)
+        btns = QDialogButtonBox(
+                QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
+                QtCore.Qt.Horizontal, self)
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
 
-        box = QVBoxLayout(self)
+        box = QtWidgets.QVBoxLayout(self)
         box.addLayout(frm)
         box.addWidget(btns)
         self.setLayout(box)
 
     def prompt_modal(self, rejection=None):
         dr = self.exec_()
-        if dr == QDialog.Accepted:
+        if dr == QtWidgets.QDialog.Accepted:
             return self.edit.text()
         else:
             return rejection
 
     def _on_completed(self, result):
         (callback, rejection) = self._on_completed_info
-        if result == QDialog.Accepted:
+        if result == QtWidgets.QDialog.Accepted:
             value = self.edit.text()
         else:
             value = rejection

--- a/hyperspyui/widgets/stringinput.py
+++ b/hyperspyui/widgets/stringinput.py
@@ -21,9 +21,9 @@ Created on Wed Jan 20 02:43:41 2016
 @author: Vidar Tonaas Fauske
 """
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 
 class StringInputDialog(QDialog):

--- a/hyperspyui/widgets/traitswidget.py
+++ b/hyperspyui/widgets/traitswidget.py
@@ -23,9 +23,9 @@ Created on Wed Jan 07 20:01:34 2015
 
 from hyperspyui.widgets.extendedqwidgets import FigureWidget
 
-from python_qt_binding import QtGui, QtCore
-from QtCore import *
-from QtGui import *
+from qtpy import QtGui, QtCore
+from qtpy.QtCore import *
+from qtpy.QtGui import *
 
 
 class TraitsWidget(FigureWidget):

--- a/hyperspyui/widgets/traitswidget.py
+++ b/hyperspyui/widgets/traitswidget.py
@@ -23,9 +23,7 @@ Created on Wed Jan 07 20:01:34 2015
 
 from hyperspyui.widgets.extendedqwidgets import FigureWidget
 
-from qtpy import QtGui, QtCore
-from qtpy.QtCore import *
-from qtpy.QtGui import *
+from qtpy import QtWidgets
 
 
 class TraitsWidget(FigureWidget):
@@ -87,8 +85,8 @@ class TraitsWidget(FigureWidget):
         self.clear_editor()
         # Fix resizing
         sp = traits_dialog.sizePolicy()
-        sp.setVerticalPolicy(QSizePolicy.Fixed)
-        sp.setHorizontalPolicy(QSizePolicy.Expanding)
+        sp.setVerticalPolicy(QtWidgets.QSizePolicy.Fixed)
+        sp.setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
         traits_dialog.layout().setSizeConstraint(QLayout.SetDefaultConstraint)
         traits_dialog.setSizePolicy(sp)
 

--- a/hyperspyui/widgets/traitswidget.py
+++ b/hyperspyui/widgets/traitswidget.py
@@ -87,7 +87,8 @@ class TraitsWidget(FigureWidget):
         sp = traits_dialog.sizePolicy()
         sp.setVerticalPolicy(QtWidgets.QSizePolicy.Fixed)
         sp.setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
-        traits_dialog.layout().setSizeConstraint(QLayout.SetDefaultConstraint)
+        traits_dialog.layout().setSizeConstraint(
+                QtWidgets.QLayout.SetDefaultConstraint)
         traits_dialog.setSizePolicy(sp)
 
         # Set widget

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     license='GPLv3',
     packages=find_packages(exclude=['tests*',
                                     'hyperspyui.plugins.user_plugins']),
-    requires=['hyperspy (>= 1.3.0)',
+    requires=['hyperspy (>= 1.1.1)',
               'matplotlib (>= 1.3)',
               'pyqode.python (>= 2.6.0)',
               'autopep8',
@@ -47,7 +47,7 @@ setup(
               'qtconsole',
               'qtpy',
               ],
-    install_requires=['hyperspy >= 1.3.0',
+    install_requires=['hyperspy >= 1.1.1',
                       'matplotlib >= 1.3',
                       'pyqode.python >= 2.6.0',
                       'pyface',  # >=6.0.0 for pyqt5

--- a/setup.py
+++ b/setup.py
@@ -37,23 +37,25 @@ setup(
     license='GPLv3',
     packages=find_packages(exclude=['tests*',
                                     'hyperspyui.plugins.user_plugins']),
-    requires=['hyperspy (>= 1.1.1)',
+    requires=['hyperspy (>= 1.3.0)',
               'matplotlib (>= 1.3)',
-              'python_qt_binding',
               'pyqode.python (>= 2.6.0)',
               'autopep8',
+              'pyface', #  (>=6.0.0) for pyqt5
               'traits',
-              'traitsui',
+              'traitsui',  # (>=5.2.0) for pyqt5
               'qtconsole',
+              'qtpy',
               ],
-    install_requires=['hyperspy >= 1.1.1',
+    install_requires=['hyperspy >= 1.3.0',
                       'matplotlib >= 1.3',
-                      'python_qt_binding',
                       'pyqode.python >= 2.6.0',
+                      'pyface',  # >=6.0.0 for pyqt5
                       'autopep8',
                       'traits',
-                      'traitsui',
+                      'traitsui',  # >=5.2.0 for pyqt5
                       'qtconsole',
+                      'qtpy',
                       ],
     extras_require={
         ':sys_platform == "win32"': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 
 import hyperspyui
+from hyperspyui.__main__ import get_splash
 
 import pytest
 
@@ -48,7 +49,7 @@ def pytest_unconfigure(config):
 def mainwindow(qapp):
     from hyperspyui.mainwindow import MainWindow
 
-    window = MainWindow(argv=[])
+    window = MainWindow(get_splash(), argv=[])
     yield window
     qapp.processEvents()
     window.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 
-import sys
 import os
 import tempfile
 import shutil

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import hyperspyui
 
 import pytest
 
-from python_qt_binding import QtCore
+from qtpy import QtCore
 
 QCoreApplication = QtCore.QCoreApplication
 QSettings = QtCore.QSettings

--- a/tests/single_app.py
+++ b/tests/single_app.py
@@ -1,6 +1,6 @@
 import sys
 from hyperspyui.singleapplication import get_app
-from python_qt_binding import QT_BINDING
+from qtpy import API
 
 key = 'test_single_app'
 
@@ -16,9 +16,9 @@ except SystemExit:
     print('Exiting early!')
     raise
 
-if QT_BINDING == 'pyqt':
+if "pyqt" in API:
     app.messageAvailable.connect(handle_second_instance)
-elif QT_BINDING == 'pyside':
+elif API == 'pyside':
     app.messageReceived.connect(handle_second_instance)
 
 print('Loaded app')


### PR DESCRIPTION
Continuation of #144 to port to qtpy to support qt5. This PR needs pyface and traitsui development version to work. It works fairly nicely with qt5 and qt4 -I haven't tried pyside.

### Progress:
- [x] port to qtpy
- [x] update to new-style signal-slot connection
- [x] workaround for the floating console with pyqt5 hidden after start
- [x] fix issue with progressbar
- [x] ~~fix issue with a plotting issue with qt5: when a signal is plotted, an additional call to `update()` is necessary, for example resizing the window is enough.~~ This is actually a ~~matplotlib~~ hyperspy issue with matpltolib versions 2.1 and 2.2 and it works fine with 2.0. This is now fixed in https://github.com/hyperspy/hyperspy/pull/1890.
- [x] ready for review