### PR TITLE
Fixed version mismatch of pyqt install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Due to a dependency on pyqt version 4 (version 5 is not currently supported), to
   
     pip install hyperspyui
 
-    conda install -c menpo pyqt
+    conda install -c menpo pyqt=4
 
 And run it with:
 


### PR DESCRIPTION
Menpo has updated their pyqt to the latest, so we now must specify version 4.