### PR TITLE
BUGFIX: fixes save figure window not opening on Windows

### DIFF
--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -338,11 +338,20 @@ class MainWindowUtils(MainWindowBase):
         # Analyze suggested filename
         base, tail = os.path.split(f)
         fn, ext = os.path.splitext(tail)
+        _logger.debug('fn before cleaning is: {}'.format(fn))
 
-        # Clean filename of any illegal characters:
-        fn = "".join([c for c in fn if
-                      c.isalpha() or c.isdigit() or c == ' '
-                      or c == '_' or c == '-']).rstrip()
+        # Only allow standard ascii characters, removing
+        # the reserved ones that are not allowed
+        # Using the method from github.com/PerAkeMattias/goldfinch
+        characters = ''.join(chr(i) for i in range(255))
+        reserved_characters = '<>:"/\|?*'
+        for character in reserved_characters:
+            characters = characters.replace(character, "")
+
+        fn = ''.join(char for char in fn if char in characters)
+        fn = fn.replace('\n', '')
+
+        _logger.debug('fn after cleaning is: {}'.format(fn))
 
         # If no directory in filename, use self.cur_dir's dirname
         if base is None or base == "":
@@ -366,7 +375,6 @@ class MainWindowUtils(MainWindowBase):
             if figure is None:
                 return
         path_suggestion = self.get_figure_filepath_suggestion(figure)
-        _logger.debug('path_suggestion: {}'.format(path_suggestion))
         canvas = figure.widget()
 
         # Build type selection string

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -341,7 +341,7 @@ class MainWindowUtils(MainWindowBase):
         _logger.debug('fn before cleaning is: {}'.format(fn))
 
         # Remove illegal characters and newlines from filename:
-        reserved_characters = '<>:"/\|?*'
+        reserved_characters = r'<>:"/\|?*'
         for c in reserved_characters:
             fn = fn.replace(c, '')
         fn = fn.replace('\n', ' ')

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -34,6 +34,8 @@ from QtGui import *
 from hyperspyui.smartcolorsvgiconengine import SmartColorSVGIconEngine
 from hyperspyui.advancedaction import AdvancedAction
 
+from hyperspyui.log import logger as _logger
+
 from hyperspyui import hooktraitsui
 
 hooktraitsui.hook_traitsui()
@@ -337,6 +339,11 @@ class MainWindowUtils(MainWindowBase):
         base, tail = os.path.split(f)
         fn, ext = os.path.splitext(tail)
 
+        # Clean filename of any illegal characters:
+        fn = "".join([c for c in fn if
+                      c.isalpha() or c.isdigit() or c == ' '
+                      or c == '_' or c == '-']).rstrip()
+
         # If no directory in filename, use self.cur_dir's dirname
         if base is None or base == "":
             base = os.path.dirname(self.cur_dir)
@@ -359,6 +366,7 @@ class MainWindowUtils(MainWindowBase):
             if figure is None:
                 return
         path_suggestion = self.get_figure_filepath_suggestion(figure)
+        _logger.debug('path_suggestion: {}'.format(path_suggestion))
         canvas = figure.widget()
 
         # Build type selection string

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -340,16 +340,11 @@ class MainWindowUtils(MainWindowBase):
         fn, ext = os.path.splitext(tail)
         _logger.debug('fn before cleaning is: {}'.format(fn))
 
-        # Only allow standard ascii characters, removing
-        # the reserved ones that are not allowed
-        # Using the method from github.com/PerAkeMattias/goldfinch
-        characters = ''.join(chr(i) for i in range(255))
+        # Remove illegal characters and newlines from filename:
         reserved_characters = '<>:"/\|?*'
-        for character in reserved_characters:
-            characters = characters.replace(character, "")
-
-        fn = ''.join(char for char in fn if char in characters)
-        fn = fn.replace('\n', '')
+        for c in reserved_characters:
+            fn = fn.replace(c, '')
+        fn = fn.replace('\n', ' ')
 
         _logger.debug('fn after cleaning is: {}'.format(fn))
 


### PR DESCRIPTION
As in the title...

On windows, the title of the signals created when outputting EDS line intensity maps have a newline in them (sometimes). This throws a wrench on windows (but not Linux, for some reason). Easiest solution is to sanitize the suggested filename before opening the "Save as" dialogue box, as is done here.

Resolves #154 