### PR TITLE
Fix seg fault as reported in #161

### DIFF
--- a/hyperspyui/widgets/extendedqwidgets.py
+++ b/hyperspyui/widgets/extendedqwidgets.py
@@ -97,10 +97,9 @@ class ExClickLabel(QtWidgets.QLabel):
 class ExMessageBox(QtWidgets.QMessageBox):
 
     def isChecked(self):
-        cb = self.checkBox()
-        if cb is None:
+        if self.cb is None:
             raise AttributeError
-        return cb.checkState() == QtCore.Qt.Checked
+        return self.cb.isChecked()
 
     def setCheckBox(self, cb):
         try:
@@ -129,8 +128,8 @@ class ExRememberPrompt(ExMessageBox):
 
     def __init__(self, *args, **kwargs):
         super(ExRememberPrompt, self).__init__(*args, **kwargs)
-        cb = QtWidgets.QCheckBox(tr("Remember this choice"))
-        self.setCheckBox(cb)
+        self.cb = QtWidgets.QCheckBox(tr("Remember this choice"))
+        self.setCheckBox(self.cb)
 
 
 class ExDoubleSlider(QtWidgets.QSlider):

--- a/hyperspyui/widgets/extendedqwidgets.py
+++ b/hyperspyui/widgets/extendedqwidgets.py
@@ -128,7 +128,7 @@ class ExRememberPrompt(ExMessageBox):
 
     def __init__(self, *args, **kwargs):
         super(ExRememberPrompt, self).__init__(*args, **kwargs)
-        self.cb = QtWidgets.QCheckBox(tr("Remember this choice"))
+        self.cb = QtWidgets.QCheckBox(tr("Remember this choice"), self)
         self.setCheckBox(self.cb)
 
 

--- a/hyperspyui/widgets/pluginmanagerwidget.py
+++ b/hyperspyui/widgets/pluginmanagerwidget.py
@@ -150,10 +150,10 @@ class PluginManagerWidget(ExToolWindow):
         self.model = PluginsModel(self.plugin_manager)
         table.setModel(self.model)
         h = table.horizontalHeader()
-        h.setResizeMode(QHeaderView.ResizeToContents)
+        h.setSectionResizeMode(QHeaderView.ResizeToContents)
         table.setHorizontalHeader(h)
         h = table.verticalHeader()
-        h.setResizeMode(QHeaderView.ResizeToContents)
+        h.setSectionResizeMode(QHeaderView.ResizeToContents)
         table.setVerticalHeader(h)
         self.table = table
         width = 80


### PR DESCRIPTION
After @jat255 managed to narrow down the issue with the segmentation fault in #161, here is a fix! I have tried with pyqt5 and pyqt4 and it seems to work as expected, the checkbox is displayed and the setting is saved when requested.

There were two things misleading here: the progress bar which is display only at the end of the computation and the fact that the setting needed to reset to default when it was set previously in order to need to call the `QMessageBox` and therefore trigger the segmentation fault.