### PR TITLE
Disable version selector plugin

### DIFF
--- a/hyperspyui/__main__.py
+++ b/hyperspyui/__main__.py
@@ -87,13 +87,14 @@ def get_splash():
 
 
 def main():
-    from qtpy.QtCore import QCoreApplication
+    from qtpy.QtCore import Qt, QCoreApplication
     from qtpy.QtWidgets import QApplication
     from qtpy import API
 
     import hyperspyui.info
     from hyperspyui.settings import Settings
 
+    QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
     # Need to set early to make QSettings accessible
     QCoreApplication.setApplicationName("HyperSpyUI")
     QCoreApplication.setOrganizationName("Hyperspy")

--- a/hyperspyui/mainwindowbase.py
+++ b/hyperspyui/mainwindowbase.py
@@ -257,6 +257,8 @@ class MainWindowBase(QtWidgets.QMainWindow):
     def init_plugins(self):
         from .pluginmanager import PluginManager
         self.plugin_manager = PluginManager(self)
+        # Disable Version selector plugin until it is fixed
+        self.plugin_manager.enabled_store['Version selector'] = False
         self.plugin_manager.init_plugins()
 
     def create_default_actions(self):


### PR DESCRIPTION
Disable version selector plugin at start until it is fixed. It can still be re-enable but it is most likely that he will not be working depending on the system and the pip version.
This plugin should not use pip python API:
https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program