### PR TITLE
Fix issue with matplotlib 3.1

### DIFF
--- a/hyperspyui/widgets/consolewidget.py
+++ b/hyperspyui/widgets/consolewidget.py
@@ -43,7 +43,7 @@ class ConsoleWidget(RichJupyterWidget):
 
         # Set the kernel data
         self.kernel = kernel_manager.kernel
-        self.kernel.gui = 'qt4'
+        self.kernel.gui = 'qt'
 
         kernel_client = kernel_manager.client()
         kernel_client.start_channels()


### PR DESCRIPTION
Because of some interaction between ipython and matplotlib, ipykernel was trying to switch backend to `qt4` because of https://github.com/hyperspy/hyperspyUI/blob/ad45c0fd3b6527c392a22a47d7434b423762930a/hyperspyui/widgets/consolewidget.py#L46

The bug prevents plotting signal and occurs with matplotlib 3.1.