### PR TITLE
Fix icon issue with pyqt 5.12

### DIFF
--- a/hyperspyui/advancedaction.py
+++ b/hyperspyui/advancedaction.py
@@ -47,4 +47,11 @@ class AdvancedAction(QtWidgets.QAction):
         self._triggered[bool].emit(checked)
         self._triggered.emit()
 
+    def setIcon(self, icon):
+        # We need to keep a reference to the icon object if not it will be
+        # garbage collected
+        # See https://www.riverbankcomputing.com/pipermail/pyqt/2019-March/041459.html
+        self.icon = icon
+        super().setIcon(icon)
+
 AdvancedAction.__init__.__doc__ = QtWidgets.QAction.__init__.__doc__

--- a/hyperspyui/advancedaction.py
+++ b/hyperspyui/advancedaction.py
@@ -51,7 +51,7 @@ class AdvancedAction(QtWidgets.QAction):
         # We need to keep a reference to the icon object if not it will be
         # garbage collected
         # See https://www.riverbankcomputing.com/pipermail/pyqt/2019-March/041459.html
-        self.icon = icon
+        self._icon = icon
         super().setIcon(icon)
 
 AdvancedAction.__init__.__doc__ = QtWidgets.QAction.__init__.__doc__

--- a/hyperspyui/mainwindowutillayer.py
+++ b/hyperspyui/mainwindowutillayer.py
@@ -86,11 +86,9 @@ class MainWindowUtils(MainWindowBase):
         self.statusBar().showMessage(msg)
 
     def _make_action(self, label, icon, shortcut, tip):
-        if icon is None:
-            ac = AdvancedAction(tr(label), self)
-        else:
-            icon = self.make_icon(icon)
-            ac = AdvancedAction(icon, tr(label), self)
+        ac = AdvancedAction(tr(label), self)
+        if icon:
+            ac.setIcon(self.make_icon(icon))
         if shortcut is not None:
             ac.setShortcut(shortcut)
         if tip is not None:


### PR DESCRIPTION
Keep a reference to the icon to avoid its garbage collection in pyqt 5.12.

See https://www.riverbankcomputing.com/pipermail/pyqt/2019-March/041459.html