### PR TITLE
Add support for EELS zlp also_align

### DIFF
--- a/hyperspyui/plugins/alignzlp.py
+++ b/hyperspyui/plugins/alignzlp.py
@@ -1,6 +1,7 @@
 from hyperspyui.plugins.plugin import Plugin
-
-
+from hyperspyui.widgets.signallist import SignalList
+from hyperspyui.log import logger
+from qtpy.QtWidgets import QDialog
 class Alignzlp(Plugin):
     name = "AlignZLP"
 
@@ -24,4 +25,22 @@ class Alignzlp(Plugin):
     def default(self):
         ui = self.ui
         s = ui.get_selected_signal()
-        s.align_zero_loss_peak()
+        logger.debug('Align zero loss peak of ' + str(s))
+        title = s.metadata.General.title
+
+        signal_list = [sig for sig in ui.signals if sig.signal is not s]
+        picker = SignalList(items=signal_list, parent=ui, multiselect=True)
+        diag = ui.show_okcancel_dialog("Select signals to align with {}".format(
+            title), picker, modal=True)
+        signals = []
+        if diag.result() == QDialog.Accepted:
+            signals = picker.get_selected()
+        else:
+            return
+        signals = [] if not signals else signals  # if none selected
+        signals = [sig.signal for sig in signals]
+        logger.debug('Also aligning the following signals\n' + str(signals))
+        # unclear how to incorporate this. It needs a blist argument
+        # picker.unbind(blist=?)
+        s.align_zero_loss_peak(also_align=signals)
+        logger.debug('ZLP alignment complete')

--- a/hyperspyui/plugins/alignzlp.py
+++ b/hyperspyui/plugins/alignzlp.py
@@ -2,6 +2,8 @@ from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.signallist import SignalList
 from hyperspyui.log import logger
 from qtpy.QtWidgets import QDialog
+
+
 class Alignzlp(Plugin):
     name = "AlignZLP"
 
@@ -32,15 +34,11 @@ class Alignzlp(Plugin):
         picker = SignalList(items=signal_list, parent=ui, multiselect=True)
         diag = ui.show_okcancel_dialog("Select signals to align with {}".format(
             title), picker, modal=True)
-        signals = []
-        if diag.result() == QDialog.Accepted:
-            signals = picker.get_selected()
-        else:
+        if diag.result() != QDialog.Accepted:
             return
-        signals = [] if not signals else signals  # if none selected
+        signals = picker.get_selected() or []
         signals = [sig.signal for sig in signals]
-        logger.debug('Also aligning the following signals\n' + str(signals))
-        # unclear how to incorporate this. It needs a blist argument
-        # picker.unbind(blist=?)
+        logger.debug(
+            'Also aligning the following signals\n' + str(signals))
         s.align_zero_loss_peak(also_align=signals)
         logger.debug('ZLP alignment complete')

--- a/hyperspyui/plugins/alignzlp.py
+++ b/hyperspyui/plugins/alignzlp.py
@@ -1,4 +1,6 @@
+import hyperspy.signals
 from hyperspyui.plugins.plugin import Plugin
+from hyperspyui.util import SignalTypeFilter
 from hyperspyui.widgets.signallist import SignalList
 from hyperspyui.log import logger
 from qtpy.QtWidgets import QDialog
@@ -14,7 +16,9 @@ class Alignzlp(Plugin):
             self.name,
             self.default,
             icon="align_zero_loss.svg",
-            tip="")
+            tip="Align the zero loss peak of an EELS spectrum image",
+            selection_callback=SignalTypeFilter(
+                hyperspy.signals.Signal1D, self.ui))
 
     def create_menu(self):
         self.add_menuitem('EELS', self.ui.actions[self.name + '.default'])
@@ -30,7 +34,8 @@ class Alignzlp(Plugin):
         logger.debug('Align zero loss peak of ' + str(s))
         title = s.metadata.General.title
 
-        signal_list = [sig for sig in ui.signals if sig.signal is not s]
+        signal_list = [
+            sig for sig in ui.signals if sig.signal is not s and type(sig) == hyperspy.signals.EELSSpectrum]
         picker = SignalList(items=signal_list, parent=ui, multiselect=True)
         diag = ui.show_okcancel_dialog("Select signals to align with {}".format(
             title), picker, modal=True)


### PR DESCRIPTION
Fixes #137. @k8macarthur.
The Align ZLP option now by default asks the user if they want to align more signals. 

I was not sure what to do with `picker.unbind`, as @vidartf suggested in #137.