### PR TITLE
Fix checking animation writer availability

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@ Changelog
 
 v1.2.0.dev0 (UNRELEASED)
 ++++++++++++++++++++++++
-* Fix doc warning add workflow to publish the code on tag.
-* Add support for matplotlib 3.4.0 and increase hyperspy, matplotlib minimum requirement
-
+* Fix doc warning add workflow to publish the code on tag (`#198 <https://github.com/hyperspy/hyperspyUI/pull/198>`_)
+* Add support for matplotlib 3.4.0 and increase hyperspy, matplotlib minimum requirement (`#199 <https://github.com/hyperspy/hyperspyUI/pull/199>`_)
+* Fix checking animation writer availability (`#201 <https://github.com/hyperspy/hyperspyUI/pull/201>`_)
 
 v1.1.3
 ++++++

--- a/hyperspyui/plugins/moviesaver.py
+++ b/hyperspyui/plugins/moviesaver.py
@@ -34,7 +34,7 @@ def tr(text):
 # Check that we have a valid writer
 writer = mpl.rcParams['animation.writer']
 writers = animation.writers
-if writer in writers.avail:
+if writers.is_available(writer):
     writer = writers[writer]()
 else:
     import warnings


### PR DESCRIPTION
The `avail` attribute of `MovieWriterRegistry` has been deprecated in matplotlib 3.2.0.

Fix the following error:
```python
/home/eric/Dev/hyperspyUI/hyperspyui/pluginmanager.py:130: RuntimeWarning: Exception in import of hyperspyui plugin "moviesaver" error:
  File "/home/eric/Dev/hyperspyUI/hyperspyui/plugins/moviesaver.py", line 37, in <module>
    if writer in writers.avail:
AttributeError: 'MovieWriterRegistry' object has no attribute 'avail'

  self.warn("import", plug)
```