### PR TITLE
Fix deprecated `plt.get_cmap`

### DIFF
--- a/hyperspyui/plugins/cmappicker.py
+++ b/hyperspyui/plugins/cmappicker.py
@@ -22,7 +22,7 @@ Created on Wed Jan 20 22:32:58 2016
 """
 
 import numpy as np
-import matplotlib.pyplot as plt
+import matplotlib
 
 from hyperspyui.plugins.plugin import Plugin
 from hyperspyui.widgets.extendedqwidgets import FigureWidget
@@ -180,7 +180,7 @@ class CMapDelegate(QtWidgets.QItemDelegate):
             option.rect.setLeft(option.rect.x() + 10)
             super().paint(painter, option, index)
 
-            cmap = plt.get_cmap(index.data().strip())
+            cmap = matplotlib.colormaps.get_cmap(index.data().strip())
             width = self.width_ - self.cmap_shift
             line = cmap(np.linspace(0, 1, width, endpoint=True))
             line = (255 * line).astype(np.uint8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "exspy",
   "hyperspy >= 2.0rc0",
   "hyperspy-gui-traitsui >= 2.0",
-  "matplotlib >= 3.0.3",
+  "matplotlib >= 3.6.1",
   "packaging",
   "pyqode.python >= 4.0.2",
   "pyqode.core >= 4.0.10",


### PR DESCRIPTION
- Use `matplotlib.colormaps.get_cmap` instead of `plt.get_cmap`, since `plt.get_cmap` will be removed in matplotlib 3.9.
- Bump matplotlib minimum version to 3.6.1 to be able to use `matplotlib.colormaps.get_cmap`

https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm